### PR TITLE
Add MATLAB-to-Python port fidelity harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ PlaceCellAnimal2Results.mat
 helpfiles/PlaceCellAnimal1Results.mat
 helpfiles/PlaceCellAnimal2Results.mat
 helpfiles/SSGLMExampleData.mat
+tests/python_port_fidelity/*.slxc
+tests/python_port_fidelity/slprj/

--- a/tests/python_port_fidelity/+helpers/runPythonJson.m
+++ b/tests/python_port_fidelity/+helpers/runPythonJson.m
@@ -1,0 +1,6 @@
+function payload = runPythonJson(code)
+%RUNPYTHONJSON Execute Python code that assigns `json_text` and decode it.
+
+jsonText = pyrun(char(code), "json_text");
+payload = jsondecode(char(jsonText));
+end

--- a/tests/python_port_fidelity/README.md
+++ b/tests/python_port_fidelity/README.md
@@ -1,0 +1,27 @@
+# Python Port Fidelity Tests
+
+This test suite validates the standalone Python `nSTAT-python` port directly from MATLAB
+through `pyenv` and `py.` imports.
+
+Run from the MATLAB repo root:
+
+```matlab
+addpath(fullfile(pwd, 'tools', 'python'));
+setup_python_for_nstat_tests();
+results = runtests('tests/python_port_fidelity');
+assertSuccess(results);
+```
+
+`setup_python_for_nstat_tests` will auto-detect a `python` on your shell `PATH`
+that can import `sympy` and the standalone `nSTAT-python` package. You can also
+override the interpreter explicitly:
+
+```matlab
+setup_python_for_nstat_tests('/path/to/python');
+```
+
+The suite is split into:
+
+- `TestPythonPortFidelity.m`: core class and workflow parity checks.
+- `TestPythonNotebookParity.m`: notebook/parity-audit checks driven from MATLAB.
+- `TestPythonSimulinkParity.m`: Simulink-derived workflow comparisons against the Python port.

--- a/tests/python_port_fidelity/TestPythonNotebookParity.m
+++ b/tests/python_port_fidelity/TestPythonNotebookParity.m
@@ -1,0 +1,79 @@
+classdef TestPythonNotebookParity < matlab.unittest.TestCase
+    %TESTPYTHONNOTEBOOKPARITY Validate Python notebook/helpfile parity from MATLAB.
+
+    properties (Access = private)
+        RootDir char
+        PythonRepo char
+    end
+
+    methods (TestClassSetup)
+        function setup(tc)
+            tc.RootDir = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+            addpath(fullfile(tc.RootDir, 'tools', 'python'));
+            addpath(fullfile(tc.RootDir, 'tests', 'python_port_fidelity'));
+            [~, tc.PythonRepo] = setup_python_for_nstat_tests();
+            addpath(tc.RootDir);
+        end
+    end
+
+    methods (Test)
+        function testNotebookAuditReportsCoreHelpfileParity(tc)
+            payload = helpers.runPythonJson(strjoin({
+                'import json'
+                'from pathlib import Path'
+                'import yaml'
+                sprintf('repo = Path(r''%s'')', strrep(tc.PythonRepo, '\', '\\'))
+                'entries = yaml.safe_load((repo / ''parity'' / ''notebook_fidelity.yml'').read_text())[''items'']'
+                'topics = {''TrialExamples'', ''AnalysisExamples'', ''nSTATPaperExamples'', ''PPSimExample'', ''NetworkTutorial'', ''ValidationDataSet''}'
+                'selected = [entry for entry in entries if entry[''topic''] in topics]'
+                'json_text = json.dumps(selected)'
+            }, newline));
+
+            tc.verifyNumElements(payload, 6);
+            for k = 1:numel(payload)
+                tc.verifyTrue(any(strcmp(string(payload(k).fidelity_status), ["high_fidelity", "exact"])));
+                tc.verifyEqual(payload(k).section_delta, 0);
+                tc.verifyEqual(payload(k).figure_delta, 0);
+                tc.verifyFalse(payload(k).python_contains_placeholders);
+                tc.verifyFalse(payload(k).python_contains_tracker_only_cells);
+            end
+        end
+
+        function testNotebookAuditPromotesStimulusDecode2DToHighFidelity(tc)
+            payload = helpers.runPythonJson(strjoin({
+                'import json'
+                'from pathlib import Path'
+                'import yaml'
+                sprintf('repo = Path(r''%s'')', strrep(tc.PythonRepo, '\', '\\'))
+                'entries = yaml.safe_load((repo / ''parity'' / ''notebook_fidelity.yml'').read_text())[''items'']'
+                'entry = next(item for item in entries if item[''topic''] == ''StimulusDecode2D'')'
+                'json_text = json.dumps(entry)'
+            }, newline));
+
+            tc.verifyTrue(any(strcmp(string(payload.fidelity_status), ["high_fidelity", "exact"])));
+            tc.verifyEqual(payload.section_delta, 0);
+            tc.verifyEqual(payload.figure_delta, 0);
+            tc.verifyFalse(payload.python_contains_placeholders);
+            tc.verifyFalse(payload.python_contains_tracker_only_cells);
+        end
+
+        function testRepresentativePythonNotebookExecutionFromMatlab(tc)
+            payload = helpers.runPythonJson(strjoin({
+                'import json'
+                'import subprocess'
+                'import sys'
+                'from pathlib import Path'
+                sprintf('repo = Path(r''%s'')', strrep(tc.PythonRepo, '\', '\\'))
+                'cmd = [sys.executable, ''tools/notebooks/run_notebooks.py'', ''--group'', ''full'', ''--topics'', ''TrialExamples,PPSimExample'', ''--timeout'', ''1200'']'
+                'proc = subprocess.run(cmd, cwd=repo, capture_output=True, text=True)'
+                'json_text = json.dumps({'
+                '    ''returncode'': int(proc.returncode),'
+                '    ''stdout_tail'': proc.stdout.splitlines()[-10:],'
+                '    ''stderr_tail'': proc.stderr.splitlines()[-10:]'
+                '})'
+            }, newline));
+
+            tc.verifyEqual(payload.returncode, 0, sprintf('Notebook runner failed.\nSTDOUT:\n%s\nSTDERR:\n%s', strjoin(string(payload.stdout_tail), newline), strjoin(string(payload.stderr_tail), newline)));
+        end
+    end
+end

--- a/tests/python_port_fidelity/TestPythonPortFidelity.m
+++ b/tests/python_port_fidelity/TestPythonPortFidelity.m
@@ -1,0 +1,241 @@
+classdef TestPythonPortFidelity < matlab.unittest.TestCase
+    %TESTPYTHONPORTFIDELITY Load Python nSTAT objects directly from MATLAB.
+
+    properties (Access = private)
+        RootDir char
+        PythonRepo char
+    end
+
+    methods (TestClassSetup)
+        function setup(tc)
+            tc.RootDir = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+            addpath(fullfile(tc.RootDir, 'tools', 'python'));
+            addpath(fullfile(tc.RootDir, 'tests', 'python_port_fidelity'));
+            [~, tc.PythonRepo] = setup_python_for_nstat_tests();
+            addpath(tc.RootDir);
+        end
+    end
+
+    methods (Test)
+        function testSignalObjConstructionAndSubSignal(tc)
+            t = (0:0.1:0.4)';
+            x = [sin(t), cos(t)];
+            sig = SignalObj(t, x, 'TestSignal', 'time', 's', 'a.u.', {'s1', 's2'});
+            subSig = sig.getSubSignal(1);
+
+            payload = helpers.runPythonJson(strjoin({
+                'import json'
+                'import numpy as np'
+                'import nstat'
+                't = np.arange(0.0, 0.5, 0.1)'
+                'x = np.column_stack([np.sin(t), np.cos(t)])'
+                'sig = nstat.SignalObj(t, x, ''TestSignal'', ''time'', ''s'', ''a.u.'', [''s1'', ''s2''])'
+                'sub = sig.getSubSignal(1)'
+                'json_text = json.dumps({'
+                '    ''time'': np.asarray(sig.time, dtype=float).tolist(),'
+                '    ''data'': np.asarray(sig.data, dtype=float).tolist(),'
+                '    ''sampleRate'': float(sig.sampleRate),'
+                '    ''sub_data'': np.asarray(sub.data, dtype=float).tolist()'
+                '})'
+            }, newline));
+
+            tc.verifyEqual(payload.time(:), sig.time(:), 'AbsTol', 1e-12);
+            tc.verifyEqual(payload.data, sig.data, 'AbsTol', 1e-12);
+            tc.verifyEqual(payload.sampleRate, sig.sampleRate, 'AbsTol', 1e-12);
+            tc.verifyEqual(payload.sub_data, subSig.data, 'AbsTol', 1e-12);
+        end
+
+        function testNSpikeTrainSignalRepresentation(tc)
+            nst = nspikeTrain([0.1 0.3 0.35]);
+            nst.setMinTime(0);
+            nst.setMaxTime(0.5);
+            sigRep = nst.getSigRep(0.1);
+            spikeTimes = nst.getSpikeTimes();
+
+            payload = helpers.runPythonJson(strjoin({
+                'import json'
+                'import numpy as np'
+                'import nstat'
+                'nst = nstat.nspikeTrain([0.1, 0.3, 0.35])'
+                'nst.setMinTime(0.0)'
+                'nst.setMaxTime(0.5)'
+                'sig_rep = nst.getSigRep(0.1)'
+                'json_text = json.dumps({'
+                '    ''spike_times'': np.asarray(nst.getSpikeTimes(), dtype=float).tolist(),'
+                '    ''sampleRate'': float(nst.sampleRate),'
+                '    ''sig_rep'': np.asarray(sig_rep.data, dtype=float).tolist()'
+                '})'
+            }, newline));
+
+            tc.verifyEqual(payload.spike_times(:), spikeTimes(:), 'AbsTol', 1e-12);
+            tc.verifyEqual(payload.sampleRate, nst.sampleRate, 'AbsTol', 1e-12);
+            tc.verifyEqual(payload.sig_rep, sigRep.data, 'AbsTol', 1e-12);
+        end
+
+        function testCovariateConfidenceIntervalAgainstPython(tc)
+            t = (0:0.1:0.4)';
+            cov = Covariate(t, sin(t), 'Stimulus', 'time', 's', 'a.u.', {'stim'});
+            ci = ConfidenceInterval(t, [sin(t)-0.1, sin(t)+0.1], 'CI', 'time', 's', 'a.u.');
+            cov.setConfInterval(ci);
+
+            payload = helpers.runPythonJson(strjoin({
+                'import json'
+                'import numpy as np'
+                'import nstat'
+                't = np.arange(0.0, 0.5, 0.1)'
+                'cov = nstat.Covariate(t, np.sin(t), ''Stimulus'', ''time'', ''s'', ''a.u.'', [''stim''])'
+                'ci = nstat.ConfidenceInterval(t, np.column_stack([np.sin(t)-0.1, np.sin(t)+0.1]), ''b'')'
+                'cov.setConfInterval(ci)'
+                'json_text = json.dumps({'
+                '    ''ci_set'': bool(cov.isConfIntervalSet()),'
+                '    ''lower'': np.asarray(cov.ci[0].lower, dtype=float).tolist(),'
+                '    ''upper'': np.asarray(cov.ci[0].upper, dtype=float).tolist()'
+                '})'
+            }, newline));
+
+            tc.verifyTrue(payload.ci_set);
+            tc.verifyEqual(payload.lower(:), ci.data(:, 1), 'AbsTol', 1e-12);
+            tc.verifyEqual(payload.upper(:), ci.data(:, 2), 'AbsTol', 1e-12);
+        end
+
+        function testNSTCollCollectionSurfaceAgainstPython(tc)
+            n1 = nspikeTrain([0.1 0.3], '1', 10, 0, 0.5, 'time', 's', '', '', -1);
+            n2 = nspikeTrain([0.2], '2', 10, 0, 0.5, 'time', 's', '', '', -1);
+            coll = nstColl({n1, n2});
+            dataMat = coll.dataToMatrix([1 2], 0.1, 0.0, 0.5);
+
+            payload = helpers.runPythonJson(strjoin({
+                'import json'
+                'import numpy as np'
+                'import nstat'
+                'n1 = nstat.nspikeTrain([0.1, 0.3], ''1'', 10.0, 0.0, 0.5, ''time'', ''s'', '''', '''', -1)'
+                'n2 = nstat.nspikeTrain([0.2], ''2'', 10.0, 0.0, 0.5, ''time'', ''s'', '''', '''', -1)'
+                'coll = nstat.nstColl([n1, n2])'
+                'data_mat = np.asarray(coll.dataToMatrix([1, 2], 0.1, 0.0, 0.5), dtype=float)'
+                'json_text = json.dumps({'
+                '    ''num_spike_trains'': int(coll.numSpikeTrains),'
+                '    ''first_name'': str(coll.getNST(1).name),'
+                '    ''data_matrix'': data_mat.tolist()'
+                '})'
+            }, newline));
+
+            tc.verifyEqual(payload.num_spike_trains, coll.numSpikeTrains);
+            tc.verifyEqual(string(payload.first_name), string(coll.getNST(1).name));
+            tc.verifyEqual(payload.data_matrix, dataMat, 'AbsTol', 1e-12);
+        end
+
+        function testTrialConfigAndConfigCollSurface(tc)
+            cfg = TrialConfig({{'Baseline', 'mu'}}, 10, [], []);
+            cfg.setName('Baseline');
+            cfgColl = ConfigColl({cfg});
+            configNames = cfgColl.getConfigNames();
+
+            payload = helpers.runPythonJson(strjoin({
+                'import json'
+                'import nstat'
+                'cfg = nstat.TrialConfig([[''Baseline'', ''mu'']], 10.0, [], [], [], name=''Baseline'')'
+                'cfg_coll = nstat.ConfigColl([cfg])'
+                'json_text = json.dumps({'
+                '    ''config_name'': cfg.name,'
+                '    ''num_configs'': int(cfg_coll.numConfigs),'
+                '    ''config_names'': list(cfg_coll.configNames)'
+                '})'
+            }, newline));
+
+            tc.verifyEqual(string(payload.config_name), "Baseline");
+            tc.verifyEqual(payload.num_configs, cfgColl.numConfigs);
+            tc.verifyEqual(string(payload.config_names(:)), string(configNames(:)));
+        end
+
+        function testDecodingAlgorithmsPredictAgainstPython(tc)
+            xu = [0.1; -0.2];
+            Wu = [1.0 0.1; 0.1 2.0];
+            A = [1.0 0.2; 0.0 0.9];
+            Q = 0.05 * eye(2);
+            [xp, Wp] = DecodingAlgorithms.PPDecode_predict(xu, Wu, A, Q);
+
+            payload = helpers.runPythonJson(strjoin({
+                'import json'
+                'import numpy as np'
+                'import nstat'
+                'xu = np.array([0.1, -0.2], dtype=float)'
+                'Wu = np.array([[1.0, 0.1], [0.1, 2.0]], dtype=float)'
+                'A = np.array([[1.0, 0.2], [0.0, 0.9]], dtype=float)'
+                'Q = 0.05 * np.eye(2)'
+                'xp, Wp = nstat.DecodingAlgorithms.PPDecode_predict(xu, Wu, A, Q)'
+                'json_text = json.dumps({'
+                '    ''xp'': np.asarray(xp, dtype=float).tolist(),'
+                '    ''Wp'': np.asarray(Wp, dtype=float).tolist()'
+                '})'
+            }, newline));
+
+            tc.verifyEqual(payload.xp(:), xp(:), 'AbsTol', 1e-12);
+            tc.verifyEqual(payload.Wp, Wp, 'AbsTol', 1e-12);
+        end
+
+        function testCIFEvaluationAgainstPython(tc)
+            cif = CIF([0.1 0.5], {'stim1', 'stim2'}, {'stim1', 'stim2'}, 'binomial');
+            stimVal = [0.6; -0.2];
+
+            lambdaDelta = cif.evalLambdaDelta(stimVal);
+            gradient = cif.evalGradient(stimVal);
+            jacobian = cif.evalJacobian(stimVal);
+
+            payload = helpers.runPythonJson(strjoin({
+                'import json'
+                'import numpy as np'
+                'import nstat'
+                'cif = nstat.CIF(beta=np.array([0.1, 0.5], dtype=float), Xnames=[''stim1'', ''stim2''], stimNames=[''stim1'', ''stim2''], fitType=''binomial'')'
+                'stim_val = np.array([0.6, -0.2], dtype=float)'
+                'json_text = json.dumps({'
+                '    ''lambda_delta'': float(cif.evalLambdaDelta(stim_val)),'
+                '    ''gradient'': np.asarray(cif.evalGradient(stim_val), dtype=float).tolist(),'
+                '    ''jacobian'': np.asarray(cif.evalJacobian(stim_val), dtype=float).tolist()'
+                '})'
+            }, newline));
+
+            tc.verifyEqual(payload.lambda_delta, lambdaDelta, 'AbsTol', 1e-10);
+            tc.verifyEqual(payload.gradient(:), gradient(:), 'AbsTol', 1e-10);
+            tc.verifyEqual(payload.jacobian, jacobian, 'AbsTol', 1e-10);
+        end
+
+        function testAnalysisAndFitSummaryAgainstPython(tc)
+            t = (0:0.1:1.0)';
+            stim = Covariate(t, sin(2*pi*t), 'Stimulus', 'time', 's', '', {'stim'});
+            spikeTrain = nspikeTrain([0.1 0.4 0.7], '1', 0.1, 0.0, 1.0, 'time', 's', '', '', -1);
+            trial = Trial(nstColl({spikeTrain}), CovColl({stim}));
+            cfg = TrialConfig({{'Stimulus', 'stim'}}, 10, [], []);
+            cfg.setName('stim');
+            fit = Analysis.RunAnalysisForNeuron(trial, 1, ConfigColl({cfg}));
+            summary = FitResSummary({fit});
+
+            payload = helpers.runPythonJson(strjoin({
+                'import json'
+                'import numpy as np'
+                'import nstat'
+                't = np.arange(0.0, 1.0 + 0.1, 0.1)'
+                'stim = nstat.Covariate(t, np.sin(2*np.pi*t), ''Stimulus'', ''time'', ''s'', '''', [''stim''])'
+                'spike_train = nstat.nspikeTrain([0.1, 0.4, 0.7], ''1'', 0.1, 0.0, 1.0, ''time'', ''s'', '''', '''', -1)'
+                'trial = nstat.Trial(nstat.nstColl([spike_train]), nstat.CovColl([stim]))'
+                'cfg = nstat.TrialConfig([[''Stimulus'', ''stim'']], 10.0, [], [], name=''stim'')'
+                'fit = nstat.Analysis.RunAnalysisForNeuron(trial, 1, nstat.ConfigColl([cfg]))'
+                'summary = nstat.FitResSummary([fit])'
+                'json_text = json.dumps({'
+                '    ''aic'': float(np.asarray(fit.AIC, dtype=float)[0]),'
+                '    ''bic'': float(np.asarray(fit.BIC, dtype=float)[0]),'
+                '    ''config_name'': fit.configNames[0],'
+                '    ''summary_aic'': float(np.asarray(summary.AIC, dtype=float)[0]),'
+                '    ''bic_minus_aic'': float(np.asarray(fit.BIC, dtype=float)[0] - np.asarray(fit.AIC, dtype=float)[0])'
+                '})'
+            }, newline));
+
+            tc.verifyEqual(string(payload.config_name), string(fit.configNames{1}));
+            tc.verifyTrue(isfinite(payload.aic));
+            tc.verifyTrue(isfinite(payload.bic));
+            tc.verifyTrue(isfinite(fit.AIC(1)));
+            tc.verifyTrue(isfinite(fit.BIC(1)));
+            tc.verifyEqual(payload.bic_minus_aic, fit.BIC(1) - fit.AIC(1), 'AbsTol', 1e-10);
+            tc.verifyEqual(payload.summary_aic, payload.aic, 'AbsTol', 1e-10);
+        end
+    end
+end

--- a/tests/python_port_fidelity/TestPythonSimulinkParity.m
+++ b/tests/python_port_fidelity/TestPythonSimulinkParity.m
@@ -1,0 +1,110 @@
+classdef TestPythonSimulinkParity < matlab.unittest.TestCase
+    %TESTPYTHONSIMULINKPARITY Compare MATLAB/Simulink workflows to Python ports.
+
+    properties (Access = private)
+        RootDir char
+    end
+
+    methods (TestClassSetup)
+        function setup(tc)
+            tc.RootDir = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+            addpath(fullfile(tc.RootDir, 'tools', 'python'));
+            addpath(fullfile(tc.RootDir, 'tests', 'python_port_fidelity'));
+            setup_python_for_nstat_tests();
+            addpath(tc.RootDir);
+        end
+    end
+
+    methods (Test)
+        function testPointProcessSimulationLambdaTraceAgainstPython(tc)
+            Ts = 0.001;
+            tMin = 0;
+            tMax = 1;
+            t = tMin:Ts:tMax;
+            mu = -3;
+            H = tf([0], [1], Ts, 'Variable', 'z^-1');
+            S = tf([1], 1, Ts, 'Variable', 'z^-1');
+            E = tf([0], 1, Ts, 'Variable', 'z^-1');
+            u = sin(2*pi*1*t)';
+            e = zeros(length(t), 1);
+            stim = Covariate(t', u, 'Stimulus', 'time', 's', 'Voltage', {'sin'});
+            ens = Covariate(t', e, 'Ensemble', 'time', 's', 'Spikes', {'n1'});
+            [~, lambda] = CIF.simulateCIF(mu, H, S, E, stim, ens, 1, 'binomial');
+
+            payload = helpers.runPythonJson(strjoin({
+                'import json'
+                'import numpy as np'
+                'import nstat'
+                'Ts = 0.001'
+                't = np.arange(0.0, 1.0 + Ts, Ts)'
+                'stim = nstat.Covariate(t, np.sin(2*np.pi*1.0*t), ''Stimulus'', ''time'', ''s'', ''Voltage'', [''sin''])'
+                'ens = nstat.Covariate(t, np.zeros_like(t), ''Ensemble'', ''time'', ''s'', ''Spikes'', [''n1''])'
+                '_, lambda_cov = nstat.CIF.simulateCIF(-3.0, np.array([0.0]), np.array([1.0]), np.array([0.0]), stim, ens, 1, ''binomial'', seed=5, return_lambda=True)'
+                'json_text = json.dumps({''lambda_head'': np.asarray(lambda_cov.data[:10, 0], dtype=float).tolist()})'
+            }, newline));
+
+            tc.verifyEqual(payload.lambda_head(:), lambda.data(1:10, 1), 'AbsTol', 1e-8);
+        end
+
+        function testSimulatedNetwork2SurfaceAgainstPython(tc)
+            Ts = 0.001;
+            tMin = 0;
+            tMax = 1;
+            t = tMin:Ts:tMax;
+            mu{1} = -3; mu{2} = -3; %#ok<AGROW>
+            H{1} = tf([-4 -2 -1], [1], Ts, 'Variable', 'z^-1'); %#ok<AGROW>
+            H{2} = tf([-4 -2 -1], [1], Ts, 'Variable', 'z^-1'); %#ok<AGROW>
+            S{1} = tf([1], 1, Ts, 'Variable', 'z^-1'); %#ok<AGROW>
+            S{2} = tf([-1], 1, Ts, 'Variable', 'z^-1'); %#ok<AGROW>
+            E{1} = tf([1], 1, Ts, 'Variable', 'z^-1'); %#ok<AGROW>
+            E{2} = tf([-4], 1, Ts, 'Variable', 'z^-1'); %#ok<AGROW>
+            actNetwork = [0 1; -4 0];
+            stim = Covariate(t', sin(2*pi*1*t)', 'Stimulus', 'time', 's', 'Voltage', {'sin'});
+
+            assignin('base', 'S1', S{1}); assignin('base', 'H1', H{1}); assignin('base', 'E1', E{1}); assignin('base', 'mu1', mu{1});
+            assignin('base', 'S2', S{2}); assignin('base', 'H2', H{2}); assignin('base', 'E2', E{2}); assignin('base', 'mu2', mu{2});
+            options = simget;
+            [tout, ~, yout] = sim('SimulatedNetwork2', [stim.minTime stim.maxTime], options, stim.dataToStructure); %#ok<NASGU,ASGLU>
+            [h1Num, ~] = tfdata(H{1}, 'v');
+            [h2Num, ~] = tfdata(H{2}, 'v');
+            [s1Num, ~] = tfdata(S{1}, 'v');
+            [s2Num, ~] = tfdata(S{2}, 'v');
+            [e1Num, ~] = tfdata(E{1}, 'v');
+            [e2Num, ~] = tfdata(E{2}, 'v');
+            probMat = zeros(size(yout(:,1:2)));
+            for n = 1:size(yout, 1)
+                hist1 = 0; hist2 = 0;
+                for lag = 1:length(h1Num)
+                    if n-lag >= 1
+                        hist1 = hist1 + h1Num(lag) * yout(n-lag,1);
+                        hist2 = hist2 + h2Num(lag) * yout(n-lag,2);
+                    end
+                end
+                ens1 = 0; ens2 = 0;
+                if n > 1
+                    ens1 = e1Num(1) * yout(n-1,2);
+                    ens2 = e2Num(1) * yout(n-1,1);
+                end
+                eta1 = mu{1} + hist1 + s1Num(1) * stim.data(n) + ens1;
+                eta2 = mu{2} + hist2 + s2Num(1) * stim.data(n) + ens2;
+                probMat(n,1) = exp(eta1) / (1 + exp(eta1));
+                probMat(n,2) = exp(eta2) / (1 + exp(eta2));
+            end
+
+            payload = helpers.runPythonJson(strjoin({
+                'import json'
+                'import numpy as np'
+                'import nstat'
+                'sim = nstat.simulate_two_neuron_network(duration_s=1.0, dt=0.001, seed=4)'
+                'json_text = json.dumps({'
+                '    ''actual_network'': np.asarray(sim.actual_network, dtype=float).tolist(),'
+                '    ''lambda_head'': np.asarray(sim.lambda_delta[:5, :], dtype=float).tolist()'
+                '})'
+            }, newline));
+
+            tc.verifyEqual(payload.actual_network, actNetwork, 'AbsTol', 1e-12);
+            tc.verifySize(payload.lambda_head, [5 2]);
+            tc.verifyEqual(payload.lambda_head, probMat(1:5,:), 'AbsTol', 1e-8);
+        end
+    end
+end

--- a/tools/python/setup_python_for_nstat_tests.m
+++ b/tools/python/setup_python_for_nstat_tests.m
@@ -1,0 +1,76 @@
+function [pe, pythonRepo] = setup_python_for_nstat_tests(varargin)
+%SETUP_PYTHON_FOR_NSTAT_TESTS Configure MATLAB to import the Python nSTAT port.
+
+pythonVersion = '';
+if nargin >= 1 && ~isempty(varargin{1})
+    pythonVersion = char(string(varargin{1}));
+end
+
+thisFile = mfilename('fullpath');
+rootDir = fileparts(fileparts(fileparts(thisFile)));
+pythonRepo = fullfile(fileparts(rootDir), 'nSTAT-python');
+if exist(pythonRepo, 'dir') ~= 7
+    error('setup_python_for_nstat_tests:MissingPythonRepo', ...
+        'Expected Python port repository at %s', pythonRepo);
+end
+
+addpath(rootDir);
+addpath(fullfile(rootDir, 'helpfiles'));
+
+selectedPython = pythonVersion;
+if isempty(selectedPython)
+    selectedPython = localDiscoverPython();
+end
+
+pe = pyenv;
+if strlength(string(pe.Status)) == 0 || strcmpi(string(pe.Status), "NotLoaded")
+    if ~isempty(selectedPython)
+        pe = pyenv('Version', selectedPython);
+    else
+        pe = pyenv;
+    end
+end
+
+if isempty(selectedPython)
+    selectedPython = char(string(pe.Version));
+end
+
+escapedRepo = strrep(pythonRepo, '\', '\\');
+code = strjoin({ ...
+    'import importlib', ...
+    'import sys', ...
+    sprintf('repo = r''%s''', escapedRepo), ...
+    'if repo not in sys.path:', ...
+    '    sys.path.insert(0, repo)', ...
+    'importlib.import_module(''sympy'')', ...
+    'importlib.import_module(''nstat'')' ...
+    }, newline);
+try
+    pyrun(code);
+catch err
+    if ~isempty(selectedPython) && ~(strlength(string(pe.Status)) == 0 || strcmpi(string(pe.Status), "NotLoaded"))
+        error('setup_python_for_nstat_tests:PythonAlreadyLoaded', ...
+            ['MATLAB is already bound to a Python runtime that cannot import the ' ...
+             'nSTAT Python port dependencies. Restart MATLAB and call pyenv(''Version'', ''%s'') ' ...
+             'before loading Python, or rerun setup_python_for_nstat_tests(''%s'').'], ...
+            selectedPython, selectedPython);
+    end
+    rethrow(err);
+end
+pe = pyenv;
+end
+
+function pythonVersion = localDiscoverPython()
+pythonVersion = '';
+
+envPython = getenv('NSTAT_PYTHON');
+if ~isempty(envPython)
+    pythonVersion = char(string(envPython));
+    return;
+end
+
+[status, output] = system("python -c ""import sys, sympy; print(sys.executable)""");
+if status == 0
+    pythonVersion = strtrim(output);
+end
+end


### PR DESCRIPTION
## Summary
- add a MATLAB matlab.unittest harness that loads the standalone Python port through pyenv and py calls
- add notebook, class, and Simulink-derived parity checks plus a bootstrap helper
- ignore generated Simulink cache artifacts so only source files are versioned

## Verification
- matlab -batch "cd('/Users/iahncajigas/Library/CloudStorage/Dropbox/Codex/nSTAT'); addpath(fullfile(pwd,'tools','python')); results = runtests('tests/python_port_fidelity'); assertSuccess(results); exit"

## CI
- no GitHub Actions or MATLAB-dependent CI workflow changes were added