### PR TITLE
fix: correct time-indexing bugs in goal-directed PPDecodeFilter predict

### DIFF
--- a/DecodingAlgorithms.m
+++ b/DecodingAlgorithms.m
@@ -211,7 +211,7 @@ classdef DecodingAlgorithms
                 invA     = pinv(A);
                 invPhi0T = pinv(invA*PhitT(:,:,1));
                 ut(:,1) = (Q*invPitT)*PhitT(:,:,1)*(yT-invPhi0T*x0);
-                [x_p(:,1), W_p(:,:,1)] = DecodingAlgorithms.PPDecode_predict(x0, Pi0, Amat(:,:,min(size(Amat,3),n)), Qmat(:,:,min(size(Qmat,3))));
+                [x_p(:,1), W_p(:,:,1)] = DecodingAlgorithms.PPDecode_predict(x0, Pi0, Amat(:,:,min(size(Amat,3),1)), Qmat(:,:,min(size(Qmat,3),1)));
                 x_p(:,1) = x_p(:,1)+ut(:,1);
                 W_p(:,:,1) = W_p(:,:,1) + (Q*invPitT)*A*Pi0*A'*(Q*invPitT)';
 
@@ -234,13 +234,13 @@ classdef DecodingAlgorithms
     %             [x_p(:,n+1), W_p(:,:,n+1)] = DecodingAlgorithms.PPDecode_predict(x_u(:,n), W_u(:,:,n), Amat(:,:,min(size(A,3),n)), Qmat(:,:,min(size(Qmat,3))));
 
                 if((estimateTarget==1 && ~isempty(yT)) || isempty(yT))
-                    [x_p(:,n+1), W_p(:,:,n+1)] = DecodingAlgorithms.PPDecode_predict(x_u(:,n), W_u(:,:,n), Amat(:,:,min(size(A,3),n)), Qmat(:,:,min(size(Qmat,3))));
+                    [x_p(:,n+1), W_p(:,:,n+1)] = DecodingAlgorithms.PPDecode_predict(x_u(:,n), W_u(:,:,n), Amat(:,:,min(size(Amat,3),n)), Qmat(:,:,min(size(Qmat,3),n)));
                 else
                     %ut= Q_{t}\Pi(t,T)^{-1}\phi(t,T)(y_{T}-phi(T,t-1)x_{t-1}
                     if(n<N)
                         ut(:,n+1) = (Q*pinv(PitT(:,:,n+1)))*PhitT(:,:,n+1)*(yT-pinv(PhitT(:,:,n))*x_u(:,n));
         %                 ut(:,n+1) = ut(:,n+1)*delta;
-                        [x_p(:,n+1), W_p(:,:,n+1)] = DecodingAlgorithms.PPDecode_predict(x_u(:,n), W_u(:,:,n), Amat(:,:,min(size(A,3),n)), Qmat(:,:,min(size(Qmat,3))));
+                        [x_p(:,n+1), W_p(:,:,n+1)] = DecodingAlgorithms.PPDecode_predict(x_u(:,n), W_u(:,:,n), Amat(:,:,min(size(Amat,3),n)), Qmat(:,:,min(size(Qmat,3),n)));
                         x_p(:,n+1) = x_p(:,n+1)+ut(:,n+1);
                         W_p(:,:,n+1) = W_p(:,:,n+1) + (Q*pinv(PitT(:,:,n+1)))*A*W_u(:,:,n)*A'*(Q*pinv(PitT(:,:,n+1)))';
                     end
@@ -573,7 +573,7 @@ classdef DecodingAlgorithms
                 invA     = pinv(A1);
                 invPhi0T = pinv(invA*PhitT(:,:,1));
                 ut(:,1) = (Q1*invPitT)*PhitT(:,:,1)*(yT-invPhi0T*x0);
-                [x_p(:,1), W_p(:,:,1)] = DecodingAlgorithms.PPDecode_predict(x0, Pi0, Amat(:,:,min(size(Amat,3),n)), Qmat(:,:,min(size(Qmat,3))));
+                [x_p(:,1), W_p(:,:,1)] = DecodingAlgorithms.PPDecode_predict(x0, Pi0, Amat(:,:,min(size(Amat,3),1)), Qmat(:,:,min(size(Qmat,3),1)));
                 x_p(:,1) = x_p(:,1)+ut(:,1);
                 W_p(:,:,1) = W_p(:,:,1) + (Q1*invPitT)*A1*Pi0*A1'*(Q1*invPitT)';
 
@@ -600,7 +600,7 @@ classdef DecodingAlgorithms
                 % it is independent of the CIF
 
                 if((estimateTarget==1 && ~isempty(yT)) || isempty(yT))
-                    [x_p(:,n+1), W_p(:,:,n+1)] = DecodingAlgorithms.PPDecode_predict(x_u(:,n), W_u(:,:,n), Amat(:,:,min(size(Amat,3),n)), Qmat(:,:,min(size(Qmat,3))),Wconv);
+                    [x_p(:,n+1), W_p(:,:,n+1)] = DecodingAlgorithms.PPDecode_predict(x_u(:,n), W_u(:,:,n), Amat(:,:,min(size(Amat,3),n)), Qmat(:,:,min(size(Qmat,3),n)),Wconv);
                 else
                     %ut= Q_{t}\Pi(t,T)^{-1}\phi(t,T)(y_{T}-phi(T,t-1)x_{t-1}
                     if(n<N)
@@ -610,7 +610,7 @@ classdef DecodingAlgorithms
                         invPhitm1T = pinv(PhitT(:,:,n));
                         ut(:,n+1) = (Qn*invPitT)*PhitT(:,:,n+1)*(yT-invPhitm1T*x_u(:,n));
         %                 ut(:,n+1) = ut(:,n+1)*delta;
-                        [x_p(:,n+1), W_p(:,:,n+1)] = DecodingAlgorithms.PPDecode_predict(x_u(:,n), W_u(:,:,n), Amat(:,:,min(size(A,3),n)), Qmat(:,:,min(size(Qmat,3))));
+                        [x_p(:,n+1), W_p(:,:,n+1)] = DecodingAlgorithms.PPDecode_predict(x_u(:,n), W_u(:,:,n), Amat(:,:,min(size(Amat,3),n)), Qmat(:,:,min(size(Qmat,3),n)));
                         x_p(:,n+1) = x_p(:,n+1)+ut(:,n+1);
                         W_p(:,:,n+1) = W_p(:,:,n+1) + (Qn*invPitT)*An*W_u(:,:,n)*An'*(Qn*invPitT)';
                     end


### PR DESCRIPTION
## Summary
- Fix 6 related time-indexing bugs in `PPDecodeFilter` and `PPDecodeFilterLinear` 
- **Initialization** (lines 214, 576): stale loop variable `n` used instead of `1` for `Amat`/`Qmat` indexing
- **Main loop** (lines 237, 243, 613): `size(A,3)` instead of `size(Amat,3)` — always selected `B(:,:,1)` instead of `B(:,:,n)`
- **Main loop** (lines 237, 243, 603, 613): `min(size(Qmat,3))` missing second arg — always selected `QT(:,:,end)` instead of `QT(:,:,n)`
- `PPHybridFilterLinear` was NOT affected (already had correct indexing)

## Impact
These bugs affected the goal-directed (Srinivasan 2006) code path where `Amat=B` and `Qmat=QT` are time-varying. The filter used incorrect transition matrices and noise covariances at every time step. For time-invariant `A`/`Q` the effect was subtle (B and QT variation is small), which is why the bug went undetected.

## Test plan
- [ ] Run MATLAB `run_tests.m` — all tests pass
- [ ] Run Example 5 (PPAF decoding) — verify figures look correct
- [ ] Verified against Kalman Filter derivation document (Section 6, Srinivasan et al. 2006)

🤖 Generated with [Claude Code](https://claude.com/claude-code)