### PR TITLE
fix(ci): add Symbolic Math Toolbox to GitHub Actions runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,24 @@ jobs:
         uses: matlab-actions/setup-matlab@v2
         with:
           release: R2025b
-          # No special toolboxes required for tests/unit/*. Phase 3.5
-          # LinearCIF avoids the Symbolic Math Toolbox dependency that
-          # the legacy CIF requires; the unit-test suite does not
-          # exercise CIF, so this is sufficient for green CI.
+          # Toolbox dependencies of `tests/unit/*`:
+          #   - Statistics_and_Machine_Learning_Toolbox: glmfit (GLMFit path)
+          #   - Signal_Processing_Toolbox: periodogram, pmtm
+          #     (testSignalObjSpectralModernization)
+          #   - Symbolic_Math_Toolbox: sym() in CIF (line 159), used by
+          #     testLinearCIF (parity vs symbolic CIF),
+          #     testMPPCODeprecationShims (constructs CIF internally),
+          #     testPPDecodeUpdateIterated/testCIFMaxItersOneMatchesSingleStep.
+          #     Phase 3 Task 3.5 added LinearCIF to remove this dependency
+          #     for production code, but tests still cross-check against
+          #     the symbolic class — hence the toolbox is still required
+          #     here. Tracked as a future task: remove the symbolic-side
+          #     of the parity tests so CI can drop this dependency.
           products: >
             MATLAB
             Statistics_and_Machine_Learning_Toolbox
             Signal_Processing_Toolbox
+            Symbolic_Math_Toolbox
 
       - name: Run unit tests
         uses: matlab-actions/run-command@v2


### PR DESCRIPTION
## Summary

Hotfix for the first CI run on master (post-PR #36 merge, run `26171962010`) which failed in 2m37s with 7 test errors:

```
Undefined function 'sym' for input arguments of type 'cell'.
Error in CIF (line 159): cifObj.varIn = sym(Xnames);
```

PR #36's CI workflow comment incorrectly claimed LinearCIF eliminated the Symbolic Math Toolbox dependency. In production code that's true (Analysis.GLMFit and PP decoders no longer call CIF), but several unit tests still construct the symbolic CIF for cross-validation against LinearCIF:

- `testLinearCIF.testPoissonAgreement{NoHistory,MultiStim}`
- `testLinearCIF.testBinomialAgreement{NoHistory,MultiStim}`
- `testMPPCODeprecationShims.testDecodePredictShim{Warns,Forwards}`
- `testPPDecodeUpdateIterated.testCIFMaxItersOneMatchesSingleStep`

The parity tests are the whole point of LinearCIF — assert that closed-form derivatives match symbolic differentiation to 1e-12. The toolbox is genuinely needed for CI.

## Test plan

- [x] Local tests pass on R2025b with Symbolic Math Toolbox installed (52/52).
- [ ] CI run on this PR's branch will validate the toolbox provisioning (auto-triggered by `pull_request` event in the workflow).

## Follow-up (out of scope)

Rewrite the parity tests to consume a pre-recorded fixture of symbolic-CIF outputs rather than reconstructing the symbolic CIF at test time. Would let CI drop the Symbolic Math Toolbox dependency. Phase 4+ task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
