### PR TITLE
ci(docs): install linkify-it-py so the intro-page build succeeds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install 'sphinx>=8.0' 'sphinx-rtd-theme>=3.0' \
-            'myst-parser>=4.0' 'sphinx-design>=0.5'
+            'myst-parser>=4.0' 'sphinx-design>=0.5' \
+            'linkify-it-py>=2.0'   # required by myst_enable_extensions: linkify
 
       - name: Build the site
         run: sphinx-build -b html -W docs/ docs/_build/html


### PR DESCRIPTION
## Summary

One-line hotfix to \`.github/workflows/docs.yml\`. The intro-page build (PR #45 merge → workflow run 26722767557) failed with:

\`\`\`
ModuleNotFoundError: Linkify enabled but not installed.
\`\`\`

\`docs/conf.py\` enables \`myst_enable_extensions = [..., 'linkify', ...]\` so MyST can auto-linkify bare URLs in body prose. \`linkify-it-py\` is the backing package — \`markdown-it-py\` loads it on demand and errors at parse time if missing. The local build had it installed separately so I didn't catch this in the PR #45 dry-run.

Adds \`'linkify-it-py>=2.0'\` to the pip install in the workflow alongside the rest of the Sphinx stack.

## Test plan

- [x] Local rebuild with \`linkify-it-py\` installed succeeded with 0 warnings.
- [ ] After merge: confirm the docs workflow runs to completion and the deployed page renders at https://cajigaslab.github.io/nSTAT/.