### PR TITLE
tests: Python-fidelity classes honor NSTAT_SKIP_PARITY_TESTS

### DIFF
--- a/tests/python_port_fidelity/TestPythonNotebookParity.m
+++ b/tests/python_port_fidelity/TestPythonNotebookParity.m
@@ -8,6 +8,12 @@ classdef TestPythonNotebookParity < matlab.unittest.TestCase
 
     methods (TestClassSetup)
         function setup(tc)
+            % Cross-language fidelity is a parity test: honor the same
+            % NSTAT_SKIP_PARITY_TESTS flag TestParityAgainstBaseline uses, so
+            % run_tests('IncludeParity',false) skips (not errors) on a
+            % MATLAB-only machine without the Python port environment.
+            tc.assumeFalse(strcmp(getenv('NSTAT_SKIP_PARITY_TESTS'), '1'), ...
+                'Skipping Python-notebook parity tests via NSTAT_SKIP_PARITY_TESTS');
             tc.RootDir = fileparts(fileparts(fileparts(mfilename('fullpath'))));
             addpath(fullfile(tc.RootDir, 'tools', 'python'));
             addpath(fullfile(tc.RootDir, 'tests', 'python_port_fidelity'));

--- a/tests/python_port_fidelity/TestPythonPortFidelity.m
+++ b/tests/python_port_fidelity/TestPythonPortFidelity.m
@@ -8,6 +8,12 @@ classdef TestPythonPortFidelity < matlab.unittest.TestCase
 
     methods (TestClassSetup)
         function setup(tc)
+            % Cross-language fidelity is a parity test: honor the same
+            % NSTAT_SKIP_PARITY_TESTS flag TestParityAgainstBaseline uses, so
+            % run_tests('IncludeParity',false) skips (not errors) on a
+            % MATLAB-only machine without the Python port environment.
+            tc.assumeFalse(strcmp(getenv('NSTAT_SKIP_PARITY_TESTS'), '1'), ...
+                'Skipping Python-port parity tests via NSTAT_SKIP_PARITY_TESTS');
             tc.RootDir = fileparts(fileparts(fileparts(mfilename('fullpath'))));
             addpath(fullfile(tc.RootDir, 'tools', 'python'));
             addpath(fullfile(tc.RootDir, 'tests', 'python_port_fidelity'));


### PR DESCRIPTION
Commit 44b4f2c (authored 2026-06-09) makes TestPythonPortFidelity and TestPythonNotebookParity honor the NSTAT_SKIP_PARITY_TESTS flag that TestParityAgainstBaseline already uses, by adding an assumeFalse guard in TestClassSetup.

Background: without this guard, `run_tests('IncludeParity', false)` errored on a MATLAB-only host (no Python port env) instead of skipping. With it, those test classes are filtered out cleanly.

Per the commit message, the author verified locally on a standalone MATLAB R2025b host that `run_tests('IncludeParity', false)` returned 61 passed / 0 failed / 14 filtered after the change.

Diff: 2 files, 12 lines added.

The commit happened to live on the `scrub/foundation-model-refs` branch (committed there while that branch was still open between PR #48's push and its merge). Opening this PR is the cleanup step to land it on master.