### PR TITLE
ci(docs): opt into Node.js 24 + fix stale intro.md path filter

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
     paths:
-      - 'docs/intro.md'
+      - 'docs/index.md'
       - 'docs/paper_examples.md'
       - 'docs/conf.py'
       - 'docs/figures/**'
@@ -20,6 +20,13 @@ permissions:
 concurrency:
   group: pages
   cancel-in-progress: false
+
+# Opt into Node.js 24 ahead of GitHub Actions' 2026-06-16 default flip.
+# Avoids the "Node.js 20 actions are deprecated" warning on every deploy and
+# pre-emptively migrates actions/checkout, actions/setup-python,
+# actions/configure-pages, actions/upload-pages-artifact, actions/deploy-pages.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   build:


### PR DESCRIPTION
Two operational fixes in one commit; no behavior change.

## 1. Node.js 24 opt-in

GitHub Actions will force Node.js 24 by default starting **2026-06-16** (5 days from now); Node.js 20 will be removed from runners 2026-09-16. Every docs deploy currently emits the deprecation warning for actions/checkout, actions/setup-python, actions/configure-pages, actions/upload-pages-artifact, and actions/deploy-pages.

Setting \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24='true'\` at the workflow env level opts in now — puts us in control of the migration before GitHub flips the default.

Reference: [GitHub blog 2025-09-19 — Deprecation of Node.js 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

## 2. Stale path-filter line

The intro page source was renamed \`docs/intro.md\` → \`docs/index.md\` in PR #47 so Sphinx would generate the deployed root \`index.html\` directly. The on.push.paths filter wasn't updated — \`docs/intro.md\` is a dead match. Other filter paths (\`docs/conf.py\`, \`docs/figures/**\`, \`helpfiles/*.html\`, the workflow itself) still trigger rebuilds correctly, but edits to \`docs/index.md\` alone don't currently kick off a deploy. Fixed.

## Test plan

- [x] Local YAML syntax valid (file parses; no Sphinx changes).
- [ ] After merge: confirm the next workflow run shows zero Node.js deprecation warnings.
- [ ] After merge: edit \`docs/index.md\` in a follow-up to confirm the rebuild triggers (or verify by inspecting the workflow run's trigger paths).