### PR TITLE
fix(SignalObj): shiftMe bounds + resample-on-mutated-window (closes #14, #54, #53)

### DIFF
--- a/SignalObj.m
+++ b/SignalObj.m
@@ -1349,6 +1349,18 @@ classdef SignalObj < handle
                 end
             else
                 sObjOut = sObj.copySignal;
+                % FIX (#54): if the time window has been mutated by
+                % setMinTime/setMaxTime since construction, the cached
+                % sampleRate may still match but the time vector no longer
+                % matches the implied grid. Force a resample-on-grid in
+                % that case so downstream makeCompatible/length-mismatch
+                % paths don't see stale data.
+                if ~isnan(newSampleRate) && size(sObjOut.data,1)>1
+                    expectedLen = round((sObjOut.maxTime - sObjOut.minTime) * newSampleRate) + 1;
+                    if length(sObjOut.time) ~= expectedLen
+                        sObjOut.resampleMe(newSampleRate);
+                    end
+                end
             end
         end
         function resampleMe(sObj, newSampleRate)
@@ -1478,7 +1490,9 @@ classdef SignalObj < handle
             sTemp = sObj.shift(deltaT,updateLabels);
             sObj.data=sTemp.data;
             sObj.time=sTemp.time;
-        end        
+            sObj.minTime=sTemp.minTime; % FIX (#14): keep minTime/maxTime in sync with time vector after shift
+            sObj.maxTime=sTemp.maxTime;
+        end
         function alignTime(sObj, timeMarker,newTime)
             if(sObj.minTime<=timeMarker && sObj.maxTime>=timeMarker)
                 deltaT=newTime-timeMarker;

--- a/tests/unit/testSignalObjResampleWindowMutated.m
+++ b/tests/unit/testSignalObjResampleWindowMutated.m
@@ -1,0 +1,47 @@
+classdef testSignalObjResampleWindowMutated < matlab.unittest.TestCase
+    %TESTSIGNALOBJRESAMPLEWINDOWMUTATED regression test for issue #54.
+    %
+    % SignalObj.resample(rate) short-circuits when newSampleRate equals
+    % sObj.sampleRate. Pre-fix: even if setMinTime/setMaxTime had mutated
+    % the window without changing sampleRate, resample still skipped, so
+    % the time vector was inconsistent with (maxTime-minTime)*sampleRate+1.
+    % Downstream makeCompatible would surface this as length-mismatch
+    % failures that looked like data corruption.
+    %
+    % Post-fix: the same-rate branch also length-checks against the
+    % expected grid and forces a resampleMe when stale.
+
+    methods (Test)
+        function testSameRateAfterWindowMutationTriggersRegrid(tc)
+            t = (0:0.001:1.0)';
+            data = sin(2*pi*3*t);
+            sig = SignalObj(t, data, 'unit1');
+            originalRate = sig.sampleRate;
+            tc.assumeNotEmpty(originalRate);
+            tc.assumeTrue(isfinite(originalRate));
+
+            % Mutate the window without changing sampleRate.
+            sig.setMinTime(0.2);
+            sig.setMaxTime(0.8);
+
+            % Same-rate resample should still produce a time vector that
+            % matches the expected sample count for the mutated window.
+            out = sig.resample(originalRate);
+            expectedLen = round((out.maxTime - out.minTime) * originalRate) + 1;
+            tc.verifyEqual(length(out.time), expectedLen, ...
+                'resample at same rate must regrid when window has been mutated');
+            tc.verifyEqual(min(out.time), out.minTime, 'AbsTol', 1e-9);
+            tc.verifyEqual(max(out.time), out.maxTime, 'AbsTol', 1e-9);
+        end
+
+        function testSameRateNoMutationNoOp(tc)
+            % Sanity: same rate, no window mutation -> behavior unchanged.
+            t = (0:0.001:0.5)';
+            sig = SignalObj(t, t, 'unit1');
+            originalLen = length(sig.time);
+            out = sig.resample(sig.sampleRate);
+            tc.verifyEqual(length(out.time), originalLen, ...
+                'unmutated same-rate resample must not change the time vector length');
+        end
+    end
+end

--- a/tests/unit/testSignalObjShiftMeBounds.m
+++ b/tests/unit/testSignalObjShiftMeBounds.m
@@ -1,0 +1,39 @@
+classdef testSignalObjShiftMeBounds < matlab.unittest.TestCase
+    %TESTSIGNALOBJSHIFTMEBOUNDS regression test for issue #14.
+    %
+    % SignalObj.shiftMe must keep minTime/maxTime in sync with the shifted
+    % time vector. Pre-fix: only data/time updated, leaving stale bounds
+    % that broke alignTime, findPeaks default minDistance, and any user
+    % code reading .minTime/.maxTime after a shift.
+
+    methods (Test)
+        function testShiftUpdatesMinAndMaxTime(tc)
+            t = (0:0.001:1.0)';
+            data = sin(2*pi*5*t);
+            sig = SignalObj(t, data, 'unit1');
+
+            originalMin = sig.minTime;
+            originalMax = sig.maxTime;
+
+            deltaT = 0.5;
+            sig.shiftMe(deltaT);
+
+            tc.verifyEqual(sig.minTime, originalMin + deltaT, 'AbsTol', 1e-12, ...
+                'shiftMe must update minTime to reflect the shift');
+            tc.verifyEqual(sig.maxTime, originalMax + deltaT, 'AbsTol', 1e-12, ...
+                'shiftMe must update maxTime to reflect the shift');
+            tc.verifyEqual(min(sig.time), sig.minTime, 'AbsTol', 1e-12, ...
+                'minTime must equal min(time) after shift');
+            tc.verifyEqual(max(sig.time), sig.maxTime, 'AbsTol', 1e-12, ...
+                'maxTime must equal max(time) after shift');
+        end
+
+        function testNegativeShift(tc)
+            t = (0.5:0.001:1.5)';
+            sig = SignalObj(t, t, 'unit1');
+            sig.shiftMe(-0.5);
+            tc.verifyEqual(sig.minTime, 0.0, 'AbsTol', 1e-12);
+            tc.verifyEqual(sig.maxTime, 1.0, 'AbsTol', 1e-12);
+        end
+    end
+end


### PR DESCRIPTION
Fixes #14, fixes #54, closes #53.

## Summary

Three SignalObj-group issues from the 2026-06-12 open-issues remediation plan ([docs/superpowers/plans/2026-06-12-open-issues-remediation.md](docs/superpowers/plans/2026-06-12-open-issues-remediation.md) PR-A).

- **#14 `shiftMe` does not update `minTime`/`maxTime`** — the method now syncs the bounds with the shifted time vector via `sTemp.minTime` / `sTemp.maxTime`. Pre-fix the stale bounds broke `alignTime`, `findPeaks` default `minDistance`, and any user code reading `.minTime` / `.maxTime` after a shift.
- **#54 `resample` skips when sampleRate unchanged but window mutated** — the same-rate branch now also length-checks against the expected sample count `(maxTime - minTime) * sampleRate + 1`, and triggers `resampleMe` if the cached time vector no longer matches the implied grid.
- **#53 `times`/`rdivide` aliasing — closed as stale-fixed.** The original report was the handle-aliasing case where `s3 = s1c` (alias) caused input mutation. That has already been fixed: both `SignalObj.times` and `SignalObj.rdivide` use `s3 = s1c.copySignal` with the canonical `% FIX: was s3=s1c (handle alias); copySignal prevents mutating input` comment, and they reference the correct distinct operators (`.*` and `./`). Verified by reading both methods end-to-end during this PR.

## Test plan

- [x] Two new `matlab.unittest` classes under `tests/unit/`:
  - `testSignalObjShiftMeBounds` — minTime/maxTime sync after shift (positive and negative deltaT).
  - `testSignalObjResampleWindowMutated` — same-rate resample regrids after `setMinTime`/`setMaxTime` mutation; remains a no-op when the window is unchanged.
- [x] `tools/run_unit_tests.sh` → **56 of 56 unit tests pass** (+2 from the new tests, no regressions in the existing 54).

## Plan reference

PR-A of the [open-issues remediation plan](docs/superpowers/plans/2026-06-12-open-issues-remediation.md).