### PR TITLE
fix(CovColl): isCovPresent last-index + findMaxTime double-shift (closes #17, #18)

### DIFF
--- a/CovColl.m
+++ b/CovColl.m
@@ -371,13 +371,13 @@ classdef CovColl <handle
         function maxTime = findMaxTime(ccObj)
             % maxTime = findMaxTime(ccObj)
             % finds that maximum maxTime from all covariates.
-            
+
             maxTime=-inf;
             for i=1:ccObj.numCov
-                maxTime = max(ccObj.covArray{i}.maxTime+ccObj.covShift,maxTime);
-            end   
+                maxTime = max(ccObj.covArray{i}.maxTime,maxTime); % FIX (#18): drop in-loop +covShift; the +covShift on the return value below is the single canonical application (symmetric with findMinTime above)
+            end
             maxTime = maxTime+ccObj.covShift;
-        end    
+        end
 
         function addToColl(ccObj,cov)
             % addToColl(ccObj,cov)
@@ -427,7 +427,7 @@ classdef CovColl <handle
                 covar=ccObj.getCov(cov);
                 answer=ccObj.isCovPresent(covar);
             elseif(isa(cov,'double'))
-                if((cov>0)&&(cov<ccObj.numCov))
+                if((cov>0)&&(cov<=ccObj.numCov)) % FIX (#17): was cov<numCov (off-by-one excluded the last covariate)
                     answer=1;
                 else
                     answer=0;

--- a/tests/unit/testCovCollFindMaxTimeShift.m
+++ b/tests/unit/testCovCollFindMaxTimeShift.m
@@ -1,0 +1,47 @@
+classdef testCovCollFindMaxTimeShift < matlab.unittest.TestCase
+    %TESTCOVCOLLFINDMAXTIMESHIFT regression test for issue #18.
+    %
+    % CovColl.findMaxTime applied ccObj.covShift twice — once inside the
+    % per-covariate loop and again to the return value — yielding an
+    % inflated maxTime by exactly +covShift. Pattern was asymmetric with
+    % findMinTime which only applies the shift once. Fix removes the
+    % in-loop application; outside-loop application is the single
+    % canonical site.
+
+    methods (Test)
+        function testCovShiftAppliedOnce(tc)
+            t = (0:0.01:1.0)';
+            c1 = Covariate(t,            t,             'Cov1', 'time', 's', '', {'a'});
+            c2 = Covariate(t + 0.5, sin(2*pi*(t+0.5)), 'Cov2', 'time', 's', '', {'b'});
+            cc = CovColl({c1, c2});
+
+            % Capture raw covariate maxTimes BEFORE setCovShift mutates
+            % ccObj's cached min/maxTime (setCovShift adjusts them by
+            % +deltaT, but findMaxTime computes from the underlying
+            % covArray, not the cached values).
+            rawMaxC1 = c1.maxTime;
+            rawMaxC2 = c2.maxTime;
+
+            shift = 0.25;
+            cc.setCovShift(shift);
+            expected = max([rawMaxC1, rawMaxC2]) + shift;
+
+            actual = cc.findMaxTime;
+            tc.verifyEqual(actual, expected, 'AbsTol', 1e-12, ...
+                'findMaxTime must apply covShift exactly once (#18 regression)');
+        end
+
+        function testFindMinMaxSymmetry(tc)
+            t = (0:0.01:2.0)';
+            c1 = Covariate(t, t, 'Cov1', 'time', 's', '', {'a'});
+            cc = CovColl({c1});
+            rawMin = c1.minTime;
+            rawMax = c1.maxTime;
+            cc.setCovShift(0.1);
+
+            tc.verifyEqual(cc.findMinTime, rawMin + 0.1, 'AbsTol', 1e-12);
+            tc.verifyEqual(cc.findMaxTime, rawMax + 0.1, 'AbsTol', 1e-12, ...
+                'findMinTime and findMaxTime must apply covShift symmetrically');
+        end
+    end
+end

--- a/tests/unit/testCovCollIsCovPresentBounds.m
+++ b/tests/unit/testCovCollIsCovPresentBounds.m
@@ -1,0 +1,21 @@
+classdef testCovCollIsCovPresentBounds < matlab.unittest.TestCase
+    %TESTCOVCOLLISCOVPRESENTBOUNDS regression test for issue #17.
+    %
+    % CovColl.isCovPresent used strict less-than (cov < numCov) for the
+    % integer-index branch, so the LAST covariate (index == numCov) was
+    % incorrectly reported as absent. Fix changes to <=.
+
+    methods (Test)
+        function testLastCovariateIsPresent(tc)
+            t = (0:0.001:1.0)';
+            c1 = Covariate(t, t, 'Cov1', 'time', 's', '', {'a'});
+            c2 = Covariate(t, sin(2*pi*t), 'Cov2', 'time', 's', '', {'b'});
+            cc = CovColl({c1, c2});
+
+            tc.verifyTrue(logical(cc.isCovPresent(1)), 'first covariate must be present');
+            tc.verifyTrue(logical(cc.isCovPresent(2)), 'LAST covariate (#17 regression) must be present');
+            tc.verifyFalse(logical(cc.isCovPresent(3)), 'out-of-range index must report absent');
+            tc.verifyFalse(logical(cc.isCovPresent(0)), 'zero index must report absent');
+        end
+    end
+end


### PR DESCRIPTION
Fixes #17, fixes #18.

PR-B of the [open-issues remediation plan](docs/superpowers/plans/2026-06-12-open-issues-remediation.md).

## Summary

- **#17 `CovColl.isCovPresent` off-by-one** — the integer-index branch used `cov < ccObj.numCov` (strict less-than), so the LAST covariate index was incorrectly reported as absent. Changed to `cov <= ccObj.numCov`.
- **#18 `CovColl.findMaxTime` covShift twice** — `+ccObj.covShift` was applied once inside the per-covariate loop and again to the return value, inflating maxTime by exactly +covShift. The pattern was asymmetric with `findMinTime` which applies the shift exactly once on the return. Removed the in-loop application; the outside-loop +covShift is the single canonical site.

## Test plan

- [x] Two new `matlab.unittest` classes under `tests/unit/`:
  - `testCovCollIsCovPresentBounds` — first/last/out-of-range integer indices.
  - `testCovCollFindMaxTimeShift` — single-application of covShift; min/max symmetry.
- [x] `tools/run_unit_tests.sh` → **59 of 59 unit tests pass** (was 57; +2 new, no regressions).