### PR TITLE
fix(TrialConfig): fromStructure includes ensCovMask and correct positional order (closes #19, #58)

### DIFF
--- a/TrialConfig.m
+++ b/TrialConfig.m
@@ -159,9 +159,15 @@ classdef TrialConfig <handle
         function tcObj = fromStructure(structure)
             % tcObj is a TrialConfig object that is reconstructed from the
             % structure
-            tcObj=TrialConfig(structure.covMask,structure.sampleRate, ...
-                              structure.history,structure.ensCovHist, ...
-                              structure.covLag,structure.name);
+            % FIX (#19, #58): pre-fix this call OMITTED ensCovMask AND was
+            % positionally shifted (covLag landed in the ensCovMask slot,
+            % name landed in the covLag slot). The constructor signature
+            % is TrialConfig(covMask, sampleRate, history, ensCovHist,
+            % ensCovMask, covLag, name) -- match it exactly.
+            tcObj = TrialConfig(structure.covMask, structure.sampleRate, ...
+                                structure.history, structure.ensCovHist, ...
+                                structure.ensCovMask, structure.covLag, ...
+                                structure.name);
         end
     end
     

--- a/tests/unit/testTrialConfigRoundTrip.m
+++ b/tests/unit/testTrialConfigRoundTrip.m
@@ -1,0 +1,38 @@
+classdef testTrialConfigRoundTrip < matlab.unittest.TestCase
+    %TESTTRIALCONFIGROUNDTRIP regression test for issues #19 and #58.
+    %
+    % TrialConfig.fromStructure previously omitted ensCovMask AND had a
+    % positional argument shift in the constructor call:
+    %   - covLag landed in ensCovMask slot
+    %   - name landed in covLag slot
+    % Round-tripping a TrialConfig through toStructure -> fromStructure
+    % silently corrupted these fields. Post-fix the round-trip preserves
+    % every field.
+
+    methods (Test)
+        function testRoundTripPreservesAllFields(tc)
+            covMask = {{'Position','x'}, {'Velocity','v_x'}};
+            sampleRate = 1000;
+            history = History([0 0.005 0.025]); % 2-window history basis
+            ensCovHist = History([0 0.001]);
+            ensCovMask = logical(eye(2));        % non-default ensCovMask
+            covLag = 0.010;                       % non-default covLag
+            name = 'roundtrip_probe';
+
+            tcOriginal = TrialConfig(covMask, sampleRate, history, ...
+                                     ensCovHist, ensCovMask, covLag, name);
+
+            s = tcOriginal.toStructure();
+            tcRoundTrip = TrialConfig.fromStructure(s);
+
+            tc.verifyEqual(tcRoundTrip.sampleRate, sampleRate, ...
+                'sampleRate must round-trip');
+            tc.verifyEqual(tcRoundTrip.covLag, covLag, 'AbsTol', 1e-12, ...
+                'covLag must round-trip (#58 regression: was getting name)');
+            tc.verifyEqual(tcRoundTrip.name, name, ...
+                'name must round-trip (#58 regression: was sliding into covLag)');
+            tc.verifyEqual(tcRoundTrip.ensCovMask, ensCovMask, ...
+                'ensCovMask must round-trip (#19 regression: was omitted)');
+        end
+    end
+end


### PR DESCRIPTION
Fixes #19, fixes #58.

PR-D of the [open-issues remediation plan](docs/superpowers/plans/2026-06-12-open-issues-remediation.md).

## Summary

Single `fromStructure` change addresses both issues — they're the same root cause described from two angles.

Pre-fix:
```matlab
TrialConfig(structure.covMask, structure.sampleRate, ...
            structure.history, structure.ensCovHist, ...
            structure.covLag, structure.name);  % WRONG
```

The constructor signature is `TrialConfig(covMask, sampleRate, history, ensCovHist, ensCovMask, covLag, name)`. The above call:
1. Omits `ensCovMask` entirely (#19) — multi-neuron GLM setups lose the ensemble covariate mask on every `.mat` round-trip.
2. Shifts the remaining args positionally (#58) — `covLag` lands in `ensCovMask` slot, `name` lands in `covLag` slot, and `name` never sets.

Post-fix passes all seven arguments in canonical order.

## Test plan

- [x] `tests/unit/testTrialConfigRoundTrip` — non-default `ensCovMask`, `covLag`, `name`; round-trip through `toStructure → fromStructure` and verify each field.
- [x] `tools/run_unit_tests.sh` → **63 of 63 unit tests pass** (was 62; +1 new, no regressions).

## Note on Python port parity

Per issue #58, the Python port `nSTAT-python` has the matching bug at `_trial_config_impl.py:190-197`. This PR only fixes the MATLAB side; the Python fix should land in a paired commit to preserve gold-fixture parity. Tracked as a follow-up for the nSTAT-python repo.