### PR TITLE
fix(Analysis): Granger ensCovMask column + phiMat coefficient mask (closes #15, #51)

### DIFF
--- a/Analysis.m
+++ b/Analysis.m
@@ -1085,8 +1085,8 @@ end
                     
                     for j=1:length(neighbors)
                         ensCovMaskTemp = ensCovMask;
-                        ensCovMaskTemp(neighbors(j),neuronNum)=0;
-                    
+                        ensCovMaskTemp(neighbors(j),neuronNum(i))=0; % FIX (#15): was neuronNum (the full neuron-list), zeroed every neuron's column for this neighbor; only the specific neuron under test (index i) should be excluded
+
                         tc{2}=TrialConfig(covMask, sampleRate, history, ensCovHist, ensCovMaskTemp); tc{2}.setName([num2str(neighbors(j)) 'excluded from ' num2str(neuronNum(i))]);
                         tcc = ConfigColl(tc);             
             
@@ -1098,8 +1098,13 @@ end
                 for j=1:length(neighbors)
                     gammaMat(neighbors(j),neuronNum(i)) = fitResults{i}{j}.logLL(2)-fitResults{i}{j}.logLL(1);
                     [coeffMat, labels, SEMat] = fitResults{i}{j}.getCoeffs(1);
-                    coeffInd=strfind(labels,[num2str(neighbors(j)) ':[']);
-                    gammaVals =coeffMat(~isempty(coeffInd));
+                    % FIX (#51): coeffInd was a cellarray from strfind on a
+                    % cellarray of labels; ~isempty on a cellarray returns
+                    % a SCALAR (true if the cellarray itself is non-empty),
+                    % so coeffMat(~isempty(coeffInd)) indexed only the
+                    % first coefficient. Build a logical mask per-label.
+                    coeffMaskNeighbor = ~cellfun(@isempty, strfind(labels,[num2str(neighbors(j)) ':[']));
+                    gammaVals =coeffMat(coeffMaskNeighbor);
                     phiMat(neighbors(j),neuronNum(i)) = -sign(sum(gammaVals))*gammaMat(neighbors(j),neuronNum(i));
                     dimDiff(neighbors(j),neuronNum(i)) = abs(diff(fitResults{i}{j}.numCoeffs));
                     valConfInt(neighbors(j),neuronNum(i)) = chi2inv(confidenceInterval,dimDiff(neighbors(j),neuronNum(i)));

--- a/tests/unit/testAnalysisGrangerCoeffMask.m
+++ b/tests/unit/testAnalysisGrangerCoeffMask.m
@@ -1,0 +1,42 @@
+classdef testAnalysisGrangerCoeffMask < matlab.unittest.TestCase
+    %TESTANALYSISGRANGERCOEFFMASK regression test for issue #51.
+    %
+    % Analysis.computeGrangerCausalityMatrix used
+    %   coeffInd = strfind(labels, ['neuron_' num2str(j) ':']);
+    %   gammaVals = coeffMat(~isempty(coeffInd));
+    % `strfind` on a cellarray returns a cellarray; `~isempty` on a
+    % cellarray returns a SCALAR (true if the cellarray is non-empty),
+    % so `coeffMat(~isempty(coeffInd))` was equivalent to
+    % `coeffMat(1)` and only the first coefficient was ever consumed.
+    % The fix uses `~cellfun(@isempty, strfind(...))` which returns a
+    % per-label logical mask.
+    %
+    % This is a unit test of the mask-building pattern alone, not the
+    % full Granger pipeline (which is an integration test).
+
+    methods (Test)
+        function testMaskMatchesAllOccurrencesOfPrefix(tc)
+            labels = {'1:[0]', '1:[1]', '2:[0]', '1:[2]', '3:[0]'};
+            target = 1;
+            mask = ~cellfun(@isempty, strfind(labels, [num2str(target) ':[']));
+            tc.verifyEqual(mask, [true true false true false], ...
+                'mask must include every label whose name starts with the target neuron prefix');
+        end
+
+        function testMaskEmptyWhenPrefixAbsent(tc)
+            labels = {'2:[0]', '3:[0]'};
+            mask = ~cellfun(@isempty, strfind(labels, '1:['));
+            tc.verifyEqual(mask, [false false]);
+        end
+
+        function testSumOverMaskedCoeffs(tc)
+            labels = {'1:[0]', '1:[1]', '2:[0]', '1:[2]'};
+            coeffMat = [0.5; -0.2; 99.0; 0.4]; % neuron-1 contributes 3 coeffs; their signed sum is 0.7
+            mask = ~cellfun(@isempty, strfind(labels, '1:['));
+            gammaVals = coeffMat(mask);
+            tc.verifyEqual(numel(gammaVals), 3, ...
+                'must consume all 3 neuron-1 coefficients (pre-fix only consumed the first)');
+            tc.verifyEqual(sum(gammaVals), 0.7, 'AbsTol', 1e-12);
+        end
+    end
+end


### PR DESCRIPTION
Fixes #15, fixes #51.

PR-E of the [open-issues remediation plan](docs/superpowers/plans/2026-06-12-open-issues-remediation.md).

## Summary

Both fixes are in `Analysis.computeGrangerCausalityMatrix`.

- **#15 `ensCovMaskTemp` wrong columns** — pre-fix `ensCovMaskTemp(neighbors(j), neuronNum) = 0` zeroed the column for EVERY neuron under test. Only the specific neuron `i` (the outer loop index) should have been excluded. Changed to `neuronNum(i)`.
- **#51 `phiMat` coefficient mask** — pre-fix `coeffMat(~isempty(coeffInd))` collapsed to `coeffMat(1)` (strfind on cellarray returns cellarray; isempty on cellarray returns scalar). Replaced with `~cellfun(@isempty, strfind(...))` so the per-label mask is correct and all history-basis coefficients contribute to the sign aggregation.

## Test plan

- [x] `tests/unit/testAnalysisGrangerCoeffMask` exercises the mask-building pattern in isolation (the full Granger pipeline is an integration test, out of scope for the default gate):
  - Mask matches all label occurrences of the target neuron prefix.
  - Mask is empty when prefix is absent.
  - Sum-over-masked-coeffs proves the multi-coefficient case (3 coefficients consumed, was 1 pre-fix).
- [x] `tools/run_unit_tests.sh` → **66 of 66 unit tests pass** (was 63; +3 new, no regressions).