### PR TITLE
fix(decoding): PPAF gamma broadcast + estimateInfoMat dead assign (closes #20, #57)

### DIFF
--- a/+nstat/+decoding/PPAF.m
+++ b/+nstat/+decoding/PPAF.m
@@ -490,7 +490,7 @@ classdef PPAF
     %                 HkAll{c} = histObj.computeHistory(nst{c}).dataToMatrix;
                 end
                 if(size(gamma,2)==1 && C>1) % if more than 1 cell but only 1 gamma
-                    gammaNew(:,c) = gamma;
+                    gammaNew = repmat(gamma,1,C); % FIX (#20): was gammaNew(:,c)=gamma reusing post-loop c==C so only the last column was set
                 else
                     gammaNew=gamma;
                 end
@@ -665,12 +665,12 @@ classdef PPAF
 %                 HkAll{c} = histObj.computeHistory(nst{c}).dataToMatrix;
             end
             if(size(gamma,2)==1 && C>1) % if more than 1 cell but only 1 gamma
-                gammaNew(:,c) = gamma;
+                gammaNew = repmat(gamma,1,C); % FIX (#20): was gammaNew(:,c)=gamma reusing post-loop c==C so only the last column was set
             else
                 gammaNew=gamma;
             end
             gamma = gammaNew;
-                
+
         else
             for c=1:C
 %                 HkAll{c} = zeros(N,1);

--- a/DecodingAlgorithms.m
+++ b/DecodingAlgorithms.m
@@ -474,10 +474,14 @@ classdef DecodingAlgorithms
             Ic=zeros(J+R,J+R);
             Q=(diag(Q)); % Make sure Q is diagonal matrix
 
-
-            X=((SumXkTerms));
-            Ic(1:R,1:R) = K/2*eye(size(Q))/Q^2 +X'/Q^3;
-
+            % FIX (#57): the dead assignment
+            %     X = SumXkTerms;
+            %     Ic(1:R,1:R) = K/2*eye(size(Q))/Q^2 + X'/Q^3;
+            % previously lived here. It was unconditionally overwritten
+            % later in the same function by the canonical assignment
+            %     Ic(1:R,1:R) = K*eye(size(Q))/(2*Q^2) + (eye(size(Q))/Q^3)*SumXkTerms;
+            % Removed to drop a refactor leftover that misled readers
+            % into thinking two distinct branches existed.
 
             % Compute information of history terms
             minTime=0;

--- a/tests/unit/testPPAFGammaBroadcast.m
+++ b/tests/unit/testPPAFGammaBroadcast.m
@@ -1,0 +1,53 @@
+classdef testPPAFGammaBroadcast < matlab.unittest.TestCase
+    %TESTPPAFGAMMABROADCAST regression test for issue #20.
+    %
+    % +nstat/+decoding/PPAF.m had the multi-cell single-gamma broadcast
+    % bug at two sites (lines 493 and 668). The code reads:
+    %     for c=1:C
+    %         ...build HkAll(:,:,c)...
+    %     end
+    %     if(size(gamma,2)==1 && C>1)
+    %         gammaNew(:,c) = gamma;
+    %     ...
+    % `c` retains its post-loop value (C), so only the LAST column of
+    % gammaNew was ever populated. All earlier columns remained zero.
+    % Fix uses repmat(gamma, 1, C) instead.
+    %
+    % This is a unit test of the broadcast pattern alone: we can't call
+    % PPDecodeFilter without a full Trial/Analysis setup, but we can
+    % verify the canonical pattern produces a full-rank matrix while
+    % the bug pattern produces zeros in every column except the last.
+
+    methods (Test)
+        function testRepmatPopulatesAllColumns(tc)
+            gamma = [0.3; -0.1; 0.2];     % single-cell gamma (3 history coeffs)
+            C = 4;                          % four cells
+            gammaNew = repmat(gamma, 1, C);
+            tc.verifyEqual(size(gammaNew), [3 4]);
+            for col = 1:C
+                tc.verifyEqual(gammaNew(:,col), gamma, 'AbsTol', 1e-15, ...
+                    sprintf('column %d must equal the source gamma', col));
+            end
+        end
+
+        function testPreFixPatternOnlyFillsLastColumn(tc)
+            % Documents the historical bug shape: writing gammaNew(:,c)
+            % where c is the post-for-loop variable equal to C only
+            % populates the last column. This test does NOT exercise the
+            % shipped code; it verifies our understanding of the bug shape
+            % so future readers can see why repmat is the right fix.
+            gamma = [0.3; -0.1; 0.2];
+            C = 4;
+            for c = 1:C
+                % simulate the per-cell pre-loop body that doesn't touch gammaNew
+            end
+            % c retains the value 4 here; mimic the pre-fix line:
+            gammaNew = zeros(numel(gamma), C);
+            gammaNew(:,c) = gamma;
+            tc.verifyEqual(gammaNew(:,1), zeros(numel(gamma),1), ...
+                'pre-fix shape leaves column 1 zero (regression doc)');
+            tc.verifyEqual(gammaNew(:,end), gamma, ...
+                'pre-fix shape only fills the last column (regression doc)');
+        end
+    end
+end


### PR DESCRIPTION
Fixes #20, fixes #57.

PR-F of the [open-issues remediation plan](docs/superpowers/plans/2026-06-12-open-issues-remediation.md).

## Summary

- **#20 PPAF gamma broadcast across cells** — `+nstat/+decoding/PPAF.m` (two sites, lines 493 and 668) reused the post-for-loop variable `c == C` as the column index when broadcasting a single-cell gamma across multiple cells, so only the LAST column of `gammaNew` was ever populated. Replaced with `gammaNew = repmat(gamma, 1, C)` at both sites.
- **#57 `estimateInfoMat` dead assign** — `DecodingAlgorithms.m` lines 479 and 546 both assign `Ic(1:R,1:R)` with mathematically-equivalent-for-symmetric-input formulas, on unconditional code paths. The first was always overwritten by the second. Removed the first (and its `X=SumXkTerms` helper) and left a brief inline note explaining the cleanup.

## Test plan

- [x] `tests/unit/testPPAFGammaBroadcast` verifies the repmat fix shape and documents the pre-fix bug shape.
- [x] `estimateInfoMat` change is dead-code removal; behavior is exercised end-to-end by the existing decoding parity suite (no behavior change expected since the deleted line was always overwritten).
- [x] `tools/run_unit_tests.sh` → **68 of 68 unit tests pass** (was 66; +2 new, no regressions).