### PR TITLE
docs(README): Open-in-MATLAB-Online badge + .mltbx install path (Phase G3 partial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ nSTAT
 
 Neural Spike Train Analysis Toolbox for Matlab
 
+[![Open in MATLAB Online](https://www.mathworks.com/images/responsive/global/open-in-matlab-online.svg)](https://matlab.mathworks.com/open/github/v1?repo=cajigaslab/nSTAT&file=helpfiles/HelloNstat.m)
+[![Release](https://img.shields.io/github/v/release/cajigaslab/nSTAT?label=release)](https://github.com/cajigaslab/nSTAT/releases/latest)
+[![Paper](https://img.shields.io/badge/paper-Cajigas%202012-green)](https://doi.org/10.1016/j.jneumeth.2012.08.009)
+[![PMID](https://img.shields.io/badge/PMID-22981419-purple)](https://pubmed.ncbi.nlm.nih.gov/22981419)
+[![Python port](https://img.shields.io/badge/Python%20port-nSTAT--python-orange)](https://github.com/cajigaslab/nSTAT-python)
+
 > 📖 **Start here:** [**5-minute introduction page**](https://cajigaslab.github.io/nSTAT/) — hero, install, five runnable snippets covering simulation → fitting → KS goodness-of-fit → decoding → SSGLM, plus a paper-example thumbnail gallery and v1.4.0 release highlights.
 
 **nSTAT** is the reference MATLAB implementation of the point-process / state-space framework for spike-train analysis: PP-GLM fitting (Poisson and binomial), time-rescaling KS goodness-of-fit, PPAF (point-process adaptive filter — the spike-train analog of the Kalman filter), PPHF (hybrid discrete + continuous-state filter), SSGLM (state-space GLM for trial-drifting coefficients), and PPLFP (multi-modal spike + LFP sensor-fusion filter).
@@ -20,6 +26,12 @@ Lab websites:
 
 How to install nSTAT
 --------------------
+
+### Option A — one-click install via `.mltbx` (recommended for new users)
+
+Download the latest `nSTAT-<version>.mltbx` from the [Releases page](https://github.com/cajigaslab/nSTAT/releases/latest) and double-click it in the MATLAB Desktop. MATLAB's Add-On Manager handles the path setup, the toolbox metadata, and update notifications. After install, run `nSTAT_Install('DownloadExampleData', true)` once to fetch the figshare paper-example dataset (separate from the code).
+
+### Option B — clone the repo (recommended for contributors)
 
 1. Clone this repository and open MATLAB.
 2. Change directory to the repository root (the folder containing `nSTAT_Install.m`).


### PR DESCRIPTION
Phase G3 (partial) of the [toolbox modernization plan](docs/superpowers/plans/2026-06-13-toolbox-modernization.md).

## Two user-facing README changes

### 1. Open-in-MATLAB-Online badge

Clicking it opens `helpfiles/HelloNstat.m` in a browser MATLAB session, no local install required. **The highest-leverage single discoverability change in the modernization plan** — a discoverer who finds the README via a search engine can try the toolbox in the cloud before deciding to install.

### 2. New 'Option A' install section

Recommends the `.mltbx` one-click install (added in Phase G2 / PR #72) for new users. The existing `nSTAT_Install.m` workflow is renamed 'Option B' and kept verbatim for contributors who want the editable source tree.

Also added release-version / paper-DOI / PMID / Python-port shield badges to match the intro page's hero treatment.

## Phase G3 NOT included in this PR (deferred until owner action)

- **File Exchange listing submission** — requires the owner to fill out the [MathWorks File Exchange submission form](https://www.mathworks.com/matlabcentral/fileexchange/). Cannot be automated from this side.
- **File Exchange badge** — auto-generated by File Exchange after listing is approved.
- **`.mltbx` attached to a GitHub Release** — will land at v1.5.0 tag time.