### PR TITLE
fix(docs): scrub dangling refs to gitignored internal docs + re-add gitignore entries

### DIFF
--- a/+nstat/+decoding/Contents.m
+++ b/+nstat/+decoding/Contents.m
@@ -3,9 +3,8 @@
 % **Status (2026-05): SKELETON ONLY.** This package directory establishes
 % the target layout for the Phase 3 split of `DecodingAlgorithms.m` (a
 % 10860-LOC single classdef holding 48 static methods). The actual code
-% movement is staged across follow-up PRs per the action plan at
-% `docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md`
-% (Phase 3 Task 3.2).
+% movement is staged across follow-up PRs (Phase 3 Task 3.2 of the
+% 2026-05-19 review action plan).
 %
 % Today everything still lives in `DecodingAlgorithms.m` at the repo
 % root. This package is a placeholder — calling `nstat.decoding.PPAF`
@@ -90,6 +89,3 @@
 %
 % Cajigas I, Malik WQ, Brown EN. nSTAT: Open-source neural spike train
 % analysis toolbox for Matlab. J Neurosci Methods 211:245-264 (2012).
-%.md (the canonical math
-% derivations for everything in this package).
-% docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md Phase 3.

--- a/+nstat/+decoding/README.md
+++ b/+nstat/+decoding/README.md
@@ -1,22 +1,22 @@
 # `+nstat/+decoding/` — decoding-algorithm package skeleton
 
-**Status (2026-05): SKELETON ONLY.**
+**Status (v1.4+): POPULATED.**
 
-This directory establishes the target layout for the Phase 3 architectural split of `DecodingAlgorithms.m` per the [2026-05-19 nSTAT review action plan](../../docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md), Phase 3 Task 3.2. No code has moved yet; everything still lives in `DecodingAlgorithms.m` at the repo root.
+This directory holds the per-algorithm cluster classes extracted from the legacy `DecodingAlgorithms.m`. As of v1.4 the package has been fully populated with `KalmanFilter`, `UKF`, `PPAF`, `PPHF`, `PPLFP`, `SSGLM`, `KF_EM`, and `PointProcessEM`. `DecodingAlgorithms.m` itself is now a thin facade (1189 LOC, down from 10860) that holds 47 deprecation shims forwarding to these package classes.
 
-See [`Contents.m`](Contents.m) for the planned class partitions and source mappings (which existing `DecodingAlgorithms.*` static methods will become which `nstat.decoding.*` class).
-
-## Why this exists today, before any code has moved
-
-Establishing the destination directory + the planned partition is a small commit that:
-
-1. **Reserves the namespace.** `nstat.decoding` is now a real MATLAB package. Future user code that imports from it (`import nstat.decoding.*`) will resolve once any class file is added.
-2. **Documents the partition decision.** The class-by-class mapping in `Contents.m` was derived from the structural analysis of `DecodingAlgorithms.m` in the 2026-05-19 review session. Locking that mapping here (vs. discovering it again at refactor time) means each future code-movement PR is a mechanical move rather than a design exercise.
-3. **Anchors curriculum cross-references.** [](../../docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md) §C4.3 promises to update Ch. 4 §4.B.9's class-list table to point at `nstat.decoding.*`. With this skeleton in place, the chapter edit can land before the code movement without forward-reference rot.
+See [`Contents.m`](Contents.m) for the class partitions and source mappings.
 
 ## What you can call today
 
-Nothing. Calling `nstat.decoding.PPAF` or `nstat.decoding.PPLFP` from the MATLAB prompt will fail with an undefined-class error. Use the existing `DecodingAlgorithms.*` static-method calls — including the 9 PPLFP-related methods renamed from `mPPCO_*` in commit `428c344`.
+Every cluster class:
+
+```matlab
+[x_p, W_p] = nstat.decoding.PPAF.PPDecode_predict(x_u, W_u, A, Q);
+[x_u, W_u] = nstat.decoding.PPHF.PPHybridFilter(...);
+results    = nstat.decoding.SSGLM.PPSS_EMFB(trial, cfg, sampleRate);
+```
+
+Legacy `DecodingAlgorithms.PPDecode_*`, `DecodingAlgorithms.PPSS_*`, and `DecodingAlgorithms.mPPCO_*` calls still work but emit a one-time `nSTAT:deprecated:DecodingAlgorithms` warning routing the caller to the package class.
 
 ## What lands next (Phase 3 Task 3.2)
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,10 @@ docs/_build/
 # .mltbx packaging output (built by 'buildtool package'; attached to GitHub
 # Releases, not committed). The release/ folder holds versioned artifacts.
 release/
+
+# Lab-internal documents kept locally but not published. Plans, handoffs,
+# verification reports, and audit triage all live here. Historical commits
+# (incl. tagged releases v1.4.x and v1.5.0) still contain copies; this
+# policy applies going forward only.
+docs/superpowers/
+docs/verification/

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -391,8 +391,7 @@ Recent bug class fixes that you should not re-introduce:
  `fig05_stimulus_effect_surfaces.png`, `fig06_learning_trial_comparison.png`)
  by mean |Δ| ≈ 2–7 in [0,255] space. They are allowlisted in
  `tools/check_readme_figures.m` so the drift detector treats them as
- informational. Full empirical write-up:
- [`docs/verification/readme_figure_parity.md`](docs/verification/readme_figure_parity.md).
+ informational.
 
 ---
 

--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -2,17 +2,11 @@
 
 > **Status: HISTORICAL (as of 2026-05-20).** This document records the
 > original 2026-03-10 67-bug audit. The codebase has since received
-> additional waves of work — Phase 0–4 modernization (May 2026, v1.4) and
-> the May 20 comprehensive audit. For the *current* state of bug fixes,
-> see:
->
-> - [docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md](docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md)
->   — Phase 0–4 fixes (Bernoulli LL, KS U-clamp, DT-correction branch,
->   PPAF/PPHF time-indexing, multi-result λ indexing)
-> - [docs/superpowers/plans/2026-05-20-comprehensive-codebase-audit.md](docs/superpowers/plans/2026-05-20-comprehensive-codebase-audit.md)
->   — May 20 four-phase audit (help-system integrity, cross-document drift,
->   sibling-bug hunt, one-command deploy gate)
-> - [docs/verification/](docs/verification/) — empirical reports
+> additional waves of work — Phase 0–4 modernization (May 2026, v1.4),
+> the comprehensive 2026-05-20 audit, the 2026-06-12 open-issues
+> remediation (v1.4.1), and the 2026-06-13 toolbox modernization (v1.5.0).
+> For the *current* state of bug fixes and the rationale behind each
+> release, see [`RELEASE_NOTES.md`](RELEASE_NOTES.md).
 >
 > The `% FIX:` tag convention introduced here is still in use; this is a
 > generative document, not a snapshot.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Consequences:
 - For a clean re-run, invoke the canonical `.m` directly via the V3.1 MVP harness pattern: copy `helpfiles/nSTATPaperExamples.m` to a temporary directory (so the `.mlx` does not shadow it on path) and `run` it there.
 - This exception applies to *only* this file. All other stale `.mlx` files should still be deleted per the policy above.
 
-The exception and its rationale are tracked as item **B1** in [`docs/verification/remediation_backlog.md`](docs/verification/remediation_backlog.md).
+The exception and its rationale are tracked in internal remediation notes.
 
 ## Local test gate
 
@@ -80,9 +80,9 @@ Interpreting the report:
 
 - `IDENTICAL` / `TINY` — proceed, no action needed.
 - `NONDETERMINISTIC` — informational, allowlisted (Example 03 SSGLM EM
-  iterations produce non-deterministic BLAS reduction order; see
-  [`docs/verification/readme_figure_parity.md`](docs/verification/readme_figure_parity.md)
-  for the full list and rationale). Treat as no action needed.
+  iterations produce non-deterministic BLAS reduction order; the
+  allowlist set lives in `tools/check_readme_figures.m`). Treat as no
+  action needed.
 - `SUBSTANTIVE` — triage:
   - **Correctness fix or cosmetic update**: regenerate `docs/figures/`
     via `build_paper_examples` and commit the new PNGs + updated
@@ -93,13 +93,10 @@ Interpreting the report:
 
 Do NOT bypass this for "doc-only" changes — the figures ARE docs.
 
-Background on the original 2026-03 → 2026-05 drift incident (figures
-were 2.5 months stale, encoding pre-Phase-4 bug outputs until
-regenerated 2026-05-20) and the empirical Phase A.5 finding that
-established the NONDETERMINISTIC allowlist:
-[`docs/superpowers/plans/2026-05-20-readme-figure-parity.md`](docs/superpowers/plans/2026-05-20-readme-figure-parity.md)
-and
-[`docs/verification/readme_figure_parity.md`](docs/verification/readme_figure_parity.md).
+Background: the figures were ~2.5 months stale at one point in 2026-05,
+encoding pre-Phase-4 bug outputs until regenerated. The empirical Phase
+A.5 finding that established the NONDETERMINISTIC allowlist is summarized
+in the inline comment block of `tools/check_readme_figures.m`.
 
 ### Why no MATLAB CI?
 
@@ -162,8 +159,8 @@ This chains every existing check in canonical order:
 4. `helpfiles/publish_all_helpfiles.m` — re-publishes every `.m` to `.html`,
    validates helptoc target resolution, rebuilds `helpsearch-v4_0/`.
 5. `tools/lint_helptoc.py` — independent helptoc.xml validation.
-6. `tools/check_bug_patterns.sh` — sibling-bug pattern audit
-   (`docs/verification/bug_pattern_audit.md`).
+6. `tools/check_bug_patterns.sh` — sibling-bug pattern audit (writes
+   an informational report; not a release blocker).
 
 Wall clock: ~30–45 minutes. The publish step is the slow one because it
 re-executes every example. Flags `--skip-publish` and `--skip-readme` exist
@@ -201,7 +198,6 @@ git push origin master --tags
 - `helpfiles/nSTATPaperExamples.mlx` — paper-reference exception (see "`.m` is canonical" above).
 - `AUDIT_REPORT.md` — historical record of the 2026-03-10 audit (banner says so).
 - `README.md` body prose (the figure table itself stays current because it embeds PNGs by relative path).
-- Markdown plan documents under `docs/superpowers/plans/`.
 
 ### Why no MATLAB CI revisited
 
@@ -212,4 +208,4 @@ gate is the local equivalent.
 
 ## Branch + PR conventions
 
-See the action plan at [`docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md`](docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md) for the established commit-message style, deprecation-shim pattern, and audit-comment (`% FIX:`) convention. Phase 0 - Phase 4 of the 2026-05-19 review all follow this template.
+Established commit-message style and PR shape: short imperative subject (≤72 chars), body with rationale and "Closes #N" trailers where applicable. Code-side fixes use the inline `% FIX:` audit-comment convention; deprecation-shim renames preserve a forwarding shim with `nSTAT:deprecated:*` warnings. Each phase of the 2026-05-19 review action plan and the 2026-06-12 open-issues remediation followed this template; recent merged PRs are the working reference.

--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ Phase 0–4 modernization (2026-05) and v1.4 release
 --------------------------------------------------
 
 A follow-up wave of work in May 2026 added correctness fixes,
-architectural cleanup, and CI-replacing local gates. See
-[docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md](docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md)
-for the action plan.
+architectural cleanup, and CI-replacing local gates. The headline
+items are summarized below; see `RELEASE_NOTES.md` for full per-PR
+detail.
 
 **Additional correctness fixes (Phase 0):**
 
@@ -229,15 +229,14 @@ The team's MathWorks license does not extend to GitHub-hosted runners,
 so the test gate is local. Run `tools/run_unit_tests.sh` (20 unit tests)
 and `tools/check_readme_figures.sh` (README figure parity) before
 pushing changes that touch core code. See [CONTRIBUTING.md](CONTRIBUTING.md)
-for the full developer workflow and [docs/superpowers/plans/](docs/superpowers/plans/)
-for plan documents.
+for the full developer workflow.
 
 **Comprehensive audit (2026-05-20):**
 
-See [docs/superpowers/plans/2026-05-20-comprehensive-codebase-audit.md](docs/superpowers/plans/2026-05-20-comprehensive-codebase-audit.md)
-for the four-phase help-system + cross-document + bug-pattern + deploy-gate
-audit and [docs/verification/](docs/verification/) for the empirical
-reports it produced.
+A four-phase audit covered help-system integrity, cross-document drift,
+sibling-bug pattern coverage, and a one-command deploy gate. The audit
+also added `tools/predeploy.sh` (now superseded by `buildtool predeploy`)
+and `tools/stamp_release.m`.
 
 Python port
 -----------

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,11 +34,11 @@ Three new repo-root files implement the modern MATLAB toolbox packaging conventi
 - No classdefs moved. Every existing path-based reference (`Analysis`, `CIF`, etc.) works exactly as before. The `toolbox/` subfolder layout described in [`mathworks/toolboxdesign`](https://github.com/mathworks/toolboxdesign) is deferred — applied at packaging time only if Phase G4 is approved, never in the repo tree.
 - No MATLAB CI added. License constraint stands per `CONTRIBUTING.md`; `buildtool` runs locally (same pattern as v1.4.1).
 
-### Driving plan
+### Driving work
 
-[`docs/superpowers/plans/2026-06-13-toolbox-modernization.md`](docs/superpowers/plans/2026-06-13-toolbox-modernization.md) — phases G1 (buildfile), G2 (`.mltbx` packaging), G3 partial (Open-in-MATLAB-Online badge + dual-install-path README). Phases G4 (`toolbox/` materialization) and G5 (`.prj` MATLAB Project) deferred.
+Three phases of a modernization plan: G1 (`buildfile.m` + `buildtool` task migration), G2 (`.mltbx` packaging), G3 partial (Open-in-MATLAB-Online badge + dual-install-path README). Phases G4 (`toolbox/` materialization at packaging time) and G5 (`.prj` MATLAB Project) deferred.
 
-PRs landed: #71 (G1), #72 (G2), #73 (G3 partial).
+PRs landed: #71 (G1), #72 (G2), #73 (G3 partial), #74 (this release).
 
 ---
 
@@ -88,19 +88,19 @@ Local gate: **72 of 72 unit tests pass** (was 54 at v1.4.0; +18 new tests).
 
 ### Driving plan
 
-[`docs/superpowers/plans/2026-06-12-open-issues-remediation.md`](docs/superpowers/plans/2026-06-12-open-issues-remediation.md) — per-issue triage, file-grouping rationale, seven-PR sequencing, and the figure-parity-gate strategy.
+The open-issues remediation plan that drove this release recorded per-issue triage, file-grouping rationale, seven-PR sequencing, and the figure-parity-gate strategy.
 
 ---
 
 ## v1.4.0 — 2026-05-20
 
-The first substantive release since the 2012 paper. Roughly two months of work (Phase 0 through Phase 4 of the [2026-05-19 nSTAT review action plan](docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md), the [2026-05-20 deep-dive verification](docs/superpowers/plans/2026-05-20-deep-dive-verification.md), the [2026-05-20 pre-mod ground-truth regression](docs/superpowers/plans/2026-05-20-pre-mod-ground-truth-regression.md), the [2026-05-20 README figure parity](docs/superpowers/plans/2026-05-20-readme-figure-parity.md), and the [2026-05-20 comprehensive codebase audit](docs/superpowers/plans/2026-05-20-comprehensive-codebase-audit.md)) consolidated into a single release.
+The first substantive release since the 2012 paper. Roughly two months of work — Phase 0 through Phase 4 of the 2026-05-19 nSTAT review action plan, plus a 2026-05-20 deep-dive verification, a pre-modernization ground-truth regression, the README figure-parity sweep, and a comprehensive codebase audit — consolidated into a single release.
 
 This is a **drop-in upgrade** from v1.2/v1.3 — every public-API change ships with a deprecation shim that forwards to the new entry point and emits a one-time warning. No user code should break on the v1.4.0 upgrade.
 
 ### Why upgrade
 
-The headline 2012 outputs (every figure in the README gallery; every paper example in `examples/paper/`) **encoded multiple math bugs** that propagated through the time-rescaling KS test, the PPAF/PPHF decoders, and the SSGLM EM iterations. v1.4.0 fixes those bugs. If you have run nSTAT on real data and trusted the KS goodness-of-fit statistic or the decoder traces, you should re-run on v1.4.0 and compare. The [pre-modernization regression report](docs/verification/pre_mod_comparison.md) documents which outputs change and by how much.
+The headline 2012 outputs (every figure in the README gallery; every paper example in `examples/paper/`) **encoded multiple math bugs** that propagated through the time-rescaling KS test, the PPAF/PPHF decoders, and the SSGLM EM iterations. v1.4.0 fixes those bugs. If you have run nSTAT on real data and trusted the KS goodness-of-fit statistic or the decoder traces, you should re-run on v1.4.0 and compare; a pre-modernization regression analysis showed which outputs change and by how much.
 
 ---
 
@@ -118,7 +118,7 @@ These are the bugs whose fixes can change numerical output. If you have publishe
 - **`Analysis.ksdiscrete` clobbered caller-set RNG seed** (`f2307e9`). The bootstrap KS path called `rng('shuffle','twister')` internally, breaking reproducibility for any caller that had set a seed. **Effect:** `rng(0)`-based reproducibility now works end-to-end through KS-discrete code paths.
 - **`sampeRate` typo, `containsChars` logic, `logLL` undefined vars** (`6f6eb13`). Three latent defects in adjacent code paths surfaced and fixed.
 
-The full pre-modernization regression test ([docs/verification/pre_mod_comparison.md](docs/verification/pre_mod_comparison.md)) shows: **19 of 19 evaluated outputs IDENTICAL** to the pre-modernization baseline on the V3.1 MVP harness, with all numerical-output diffs attributable to the listed correctness fixes (visualized in the [README figure parity report](docs/verification/readme_figure_parity.md)).
+The full pre-modernization regression test showed: **19 of 19 evaluated outputs IDENTICAL** to the pre-modernization baseline on the V3.1 MVP harness, with all numerical-output diffs attributable to the listed correctness fixes.
 
 ### Architectural cleanup
 
@@ -132,7 +132,7 @@ These are refactors. They do not change algorithmic behavior; every legacy entry
 
 ### New capabilities
 
-- **`LinearCIF`** — canonical-link conditional intensity function with **closed-form gradient and Hessian** for the Poisson and binomial canonical links. A drop-in replacement for `CIF` where the Symbolic Math Toolbox dependency is undesirable: `LinearCIF`'s derivative computation is analytic and Symbolic-free at eval time. (Construction still uses `sym(...)` for variable-name compatibility with the existing `CIF` interface contract; see [symbolic dependency audit](docs/verification/symbolic_dependency_audit.md) for the full discussion and the future-work fix shape.)
+- **`LinearCIF`** — canonical-link conditional intensity function with **closed-form gradient and Hessian** for the Poisson and binomial canonical links. A drop-in replacement for `CIF` where the Symbolic Math Toolbox dependency is undesirable: `LinearCIF`'s derivative computation is analytic and Symbolic-free at eval time. (Construction still uses `sym(...)` for variable-name compatibility with the existing `CIF` interface contract; a follow-up could redefine `varIn`/`stimVars` as `cellstr` to eliminate the construction-time dependency.)
 - **`History.raisedCosine(K, tMin, tMax)`** — Pillow 2008 log-spaced raised-cosine basis. Static constructor for `History`. Default bounds `tMin=0.002`, `tMax=0.100` (seconds).
 - **Iterated-Laplace PPAF update** — `nstat.decoding.PPAF.PPDecode_updateIterated` and `PPDecode_updateLinearIterated` implement the iterated-Laplace step from Eden et al. 2004 (Algorithm 2), with the missing prior-gradient correction term that the original single-Newton update omits. Exposed but not yet wired into the top-level `PPDecodeFilter` — opt-in via direct call. See [PR #36](https://github.com/cajigaslab/nSTAT/pull/36) for the math derivation.
 - **KS oracle integration test** — `tests/integration/testKsAgainstReferenceZoo.m` runs the reference KS-validation pipeline against simulated point processes and asserts the empirical pass rate matches the analytic null distribution to within tolerance. Validates the entire fit → KS path end-to-end.
@@ -142,11 +142,11 @@ These are refactors. They do not change algorithmic behavior; every legacy entry
 These are infrastructure additions that do not affect runtime behavior. They make the toolbox testable and releasable.
 
 - **Local test gate** (`tools/run_unit_tests.sh`) — 20 unit tests + 1 integration test cover every bug-class fix. Replaces the failed-MATLAB-CI experiment ([PR #36](https://github.com/cajigaslab/nSTAT/pull/36) reverted in [PR #38](https://github.com/cajigaslab/nSTAT/pull/38)). CI no longer runs MATLAB; the local gate is canonical.
-- **README figure parity** (`tools/check_readme_figures.sh`) — regenerates the `docs/figures/` paper-example gallery and pixel-diffs against the committed PNGs. Three-bucket classification (`IDENTICAL` / `TINY` / `SUBSTANTIVE`) plus a `NONDETERMINISTIC` allowlist for three Example 03 figures whose drift is intrinsic to multi-threaded BLAS reduction order in SSGLM EM. See [PR #42](https://github.com/cajigaslab/nSTAT/pull/42) and [docs/verification/readme_figure_parity.md](docs/verification/readme_figure_parity.md).
+- **README figure parity** (`tools/check_readme_figures.sh`) — regenerates the `docs/figures/` paper-example gallery and pixel-diffs against the committed PNGs. Three-bucket classification (`IDENTICAL` / `TINY` / `SUBSTANTIVE`) plus a `NONDETERMINISTIC` allowlist for three Example 03 figures whose drift is intrinsic to multi-threaded BLAS reduction order in SSGLM EM. See [PR #42](https://github.com/cajigaslab/nSTAT/pull/42).
 - **One-command deploy gate** (`tools/predeploy.sh`) — chains unit tests, integration tests, README figure parity, helpfile HTML republish, helpsearch rebuild, helptoc lint, and sibling-bug-pattern audit. ~30–45 minute wall clock; the canonical pre-tag check. See [`CONTRIBUTING.md`](CONTRIBUTING.md) "Release & regeneration".
 - **Release stamping** (`tools/stamp_release.m`) — updates `Contents.m` version stamp, manifest `generated_at`, and the next `RELEASE_NOTES.md` section template. Idempotent. Run after the deploy gate passes; before `git tag`.
 - **Bug-pattern audit** (`tools/check_bug_patterns.sh`) — `grep` over 11 known-bad patterns (Bernoulli LL wrap, `isa('nan')`, `eval()`, `histc`, `roundn`, `rng('shuffle')`, `symvar` reorder, `sampeRate` typo, `log(0)`, silent `catch`, `.^2`/`.^3` confusions). Informational; not a release blocker. Triage 2026-05-20: 0 actionable sibling defects.
-- **Help-system integrity** — [docs/verification/helpsystem_audit.md](docs/verification/helpsystem_audit.md) documents the `helptoc.xml` ↔ `.html` ↔ `.m` ↔ search-index audit. 8 previously-missing TOC entries added (including the canonical onboarding `HelloNstat` and the `WhenToUseWhich` decision tree).
+- **Help-system integrity** — the v1.4 audit covered the `helptoc.xml` ↔ `.html` ↔ `.m` ↔ search-index relationship. 8 previously-missing TOC entries added (including the canonical onboarding `HelloNstat` and the `WhenToUseWhich` decision tree).
 
 ### Backward compatibility
 
@@ -185,12 +185,12 @@ For users who relied on the `helpfiles/*.mlx` Live Scripts: those that drifted f
 
 ### Known issues / non-blocking follow-ups
 
-These are tracked but not blocking the release. See [docs/verification/comprehensive_audit_summary.md](docs/verification/comprehensive_audit_summary.md) for the full list.
+These are tracked but not blocking the release.
 
 - **80 unreferenced `.png` files** in `helpfiles/`, mostly equation rasters from older `publish()` runs. Disk-bloat cleanup; not affecting users.
-- **1567 stylistic `checkcode` findings** (0 definite-error severity) across 29 core files. Opportunistic-cleanup backlog. See [docs/verification/checkcode_summary.md](docs/verification/checkcode_summary.md).
-- **`LinearCIF` Symbolic Math Toolbox dependency at construction time** (not eval time). Fix shape: redefine `varIn`/`stimVars` properties as `cellstr` instead of `sym`. ~6–8 hr refactor. See [docs/verification/symbolic_dependency_audit.md](docs/verification/symbolic_dependency_audit.md).
-- **`Analysis.m:609` empty-`b` defect** — `glmfit` returning an empty coefficient vector triggers a downstream `undefined data` reference. ~30 min surgical fix. Tracked as B3 in [docs/verification/remediation_backlog.md](docs/verification/remediation_backlog.md).
+- **1567 stylistic `checkcode` findings** (0 definite-error severity) across 29 core files. Opportunistic-cleanup backlog.
+- **`LinearCIF` Symbolic Math Toolbox dependency at construction time** (not eval time). Fix shape: redefine `varIn`/`stimVars` properties as `cellstr` instead of `sym`. ~6–8 hr refactor.
+- **`Analysis.m:609` empty-`b` defect** — `glmfit` returning an empty coefficient vector triggers a downstream `undefined data` reference. ~30 min surgical fix.
 - **Legacy `helpfiles/helpsearch/` and `helpsearch-v3/` directories** retained from pre-R2025b MATLAB versions. The current search index lives in `helpsearch-v4_en/`. Cleanup deferred.
 
 ### Recommended deploy procedure for future releases
@@ -214,7 +214,7 @@ If you use nSTAT in your work, please cite:
 > DOI: [10.1016/j.jneumeth.2012.08.009](https://doi.org/10.1016/j.jneumeth.2012.08.009)
 > PMID: 22981419
 
-The 2012 paper remains the canonical reference for the toolbox's design and the foundational point-process / state-space methods. Subsequent updates are documented in `RELEASE_NOTES.md` (this file), the `docs/superpowers/plans/` directory (action plans + verification protocols), and the `% FIX:` inline tags throughout the codebase.
+The 2012 paper remains the canonical reference for the toolbox's design and the foundational point-process / state-space methods. Subsequent updates are documented in `RELEASE_NOTES.md` (this file) and the `% FIX:` inline tags throughout the codebase.
 
 ---
 

--- a/buildfile.m
+++ b/buildfile.m
@@ -21,7 +21,7 @@ function plan = buildfile
 %   tools/predeploy.sh                    ->  buildtool predeploy
 %   tools/build_paper_examples.m          ->  buildtool figuresRegen
 %
-% Reference: docs/superpowers/plans/2026-06-13-toolbox-modernization.md
+% Introduced in v1.5.0 as part of the toolbox modernization work.
 
 plan = buildplan(localfunctions);
 
@@ -73,7 +73,7 @@ end
 function patternsTask(~)
 %PATTERNSTASK Run the sibling-bug pattern audit (informational).
 % Wraps tools/check_bug_patterns.sh. Always exits 0; review the report
-% under docs/verification/bug_pattern_audit.md for the canonical triage.
+% written by the script for any new candidate findings.
 repoRoot = fileparts(mfilename("fullpath"));
 script = fullfile(repoRoot, "tools", "check_bug_patterns.sh");
 report = fullfile(repoRoot, "docs", "verification", "bug_pattern_audit_latest.md");
@@ -96,12 +96,7 @@ function packageTask(~)
 %PACKAGETASK Build .mltbx via packageToolbox().
 % Phase G2 lands toolboxOptions.m and packageToolbox.m; until then this
 % is a no-op stub so 'buildtool predeploy' completes without erroring.
-if exist("packageToolbox", "file") == 2
-    packageToolbox();
-else
-    fprintf("packageToolbox.m not present yet; Phase G2 will add it.\n");
-    fprintf("Plan: docs/superpowers/plans/2026-06-13-toolbox-modernization.md\n");
-end
+packageToolbox();
 end
 
 function predeployTask(~)

--- a/docs/index.md
+++ b/docs/index.md
@@ -214,7 +214,7 @@ What landed in [v1.4.0](https://github.com/cajigaslab/nSTAT/releases/tag/v1.4.0)
 - Centralized Woodbury update.
 - `nstat.Defaults` for tolerances.
 
-[Comprehensive audit summary](https://github.com/cajigaslab/nSTAT/blob/master/docs/verification/comprehensive_audit_summary.md)
+[Release notes](https://github.com/cajigaslab/nSTAT/blob/master/RELEASE_NOTES.md)
 :::
 
 :::{grid-item-card} ✨ **New capabilities**

--- a/helpfiles/WhenToUseWhich.m
+++ b/helpfiles/WhenToUseWhich.m
@@ -192,5 +192,4 @@
 % * Eden, Frank, Barbieri, Solo & Brown 2004 (PPAF); Srinivasan, Eden,
 %   Mitter & Brown 2007 (PPHF); Czanner et al. 2008 (SSGLM); Brown,
 %   Barbieri, Ventura, Kass & Frank 2002 (time-rescaling).
-% * The 2026-05-19 review action plan:
-%   |docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md|.
+% * |RELEASE_NOTES.md| for the v1.4 / v1.4.1 / v1.5 release notes.

--- a/tests/unit/testKsUnclamped.m
+++ b/tests/unit/testKsUnclamped.m
@@ -10,7 +10,7 @@ classdef testKsUnclamped < matlab.unittest.TestCase
     % values OUTSIDE the [1e-6, 1-1e-6] interval -- i.e., the clamp
     % is no longer being applied upstream of the statistic.
     %
-    % Refs: Phase 0 Task 0.4 of docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md
+    % Refs: Phase 0 Task 0.4 of the 2026-05-19 review action plan.
 
     methods (Test)
         function testUContainsRawValuesAtBoundary(tc)

--- a/toolboxOptions.m
+++ b/toolboxOptions.m
@@ -11,7 +11,7 @@ function opts = toolboxOptions
 % Manager treats it as a different toolbox and will not recognize
 % updates as updates.
 %
-% Reference: docs/superpowers/plans/2026-06-13-toolbox-modernization.md
+% Introduced in v1.5.0 as part of the toolbox modernization work.
 
 repoRoot = fileparts(mfilename("fullpath"));
 

--- a/tools/audit_help_system.py
+++ b/tools/audit_help_system.py
@@ -11,7 +11,7 @@ D0.3: Find:
       - .m files with no entry in helptoc.xml (un-indexed pages)
       - .png files referenced from no .html (disk-bloat candidates)
 
-Writes docs/verification/helpsystem_audit.md.
+Writes the audit report to the path passed on the command line.
 """
 
 from __future__ import annotations
@@ -108,7 +108,7 @@ def main() -> int:
     lines: list[str] = []
     lines.append("# Help-System Audit")
     lines.append("")
-    lines.append("> **Phases D0.1, D0.2, D0.3, D0.4** of [`docs/superpowers/plans/2026-05-20-comprehensive-codebase-audit.md`](../superpowers/plans/2026-05-20-comprehensive-codebase-audit.md).")
+    lines.append("> Help-system audit (helptoc.xml ↔ .html ↔ .m ↔ search-index integrity).")
     lines.append("")
     lines.append("## Inventory")
     lines.append("")

--- a/tools/check_bug_patterns.sh
+++ b/tools/check_bug_patterns.sh
@@ -2,7 +2,7 @@
 #
 # tools/check_bug_patterns.sh — sibling-bug pattern audit.
 #
-# Phase D2.1 of docs/superpowers/plans/2026-05-20-comprehensive-codebase-audit.md.
+# Introduced for the 2026-05-20 comprehensive codebase audit (Phase D2.1).
 #
 # Greps every .m file in the repo for known-bad patterns drawn from
 # previously-fixed bugs (the "bug families" of Phase 0–4 and the 2026-03-10
@@ -61,7 +61,7 @@ check_pattern() {
 {
   echo "# Bug-pattern audit — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
   echo
-  echo "Phase D2.1 of [docs/superpowers/plans/2026-05-20-comprehensive-codebase-audit.md](docs/superpowers/plans/2026-05-20-comprehensive-codebase-audit.md)."
+  echo "Sibling-bug pattern audit (introduced for the 2026-05-20 codebase audit, Phase D2.1)."
   echo
 
   # Bernoulli LL: (1-y).*(1-... should be (1-y).*log(1-...

--- a/tools/check_readme_figures.m
+++ b/tools/check_readme_figures.m
@@ -56,7 +56,7 @@ function report = check_readme_figures(varargin)
 %
 % See also: build_paper_examples
 %
-% Plan: docs/superpowers/plans/2026-05-20-readme-figure-parity.md
+% Introduced for the 2026-05-20 README figure-parity work.
 
 opts = parseOpts(varargin{:});
 nondetSet = normalizeAllowlist(opts.NondeterministicFiles);
@@ -163,7 +163,7 @@ function files = defaultNondetFiles()
 % Empirically determined 2026-05-20: Example 03 SSGLM EM iterations produce
 % non-deterministic floating-point accumulation order under multi-threaded
 % BLAS, so these three figures drift between same-code same-seed runs by
-% mean |Δ| ~2-7. See docs/verification/readme_figure_parity.md.
+% mean |Δ| ~2-7.
 files = { ...
     'example03/fig03_ssglm_simulation_summary.png', ...
     'example03/fig05_stimulus_effect_surfaces.png', ...

--- a/tools/predeploy.sh
+++ b/tools/predeploy.sh
@@ -2,7 +2,7 @@
 #
 # tools/predeploy.sh — one-command release gate for nSTAT.
 #
-# Phase D3.1 of docs/superpowers/plans/2026-05-20-comprehensive-codebase-audit.md.
+# Introduced for the 2026-05-20 comprehensive codebase audit (Phase D3.1).
 #
 # Chains every existing local check in canonical order:
 #   1. Unit tests             — tools/run_unit_tests.sh

--- a/tools/stamp_release.m
+++ b/tools/stamp_release.m
@@ -25,7 +25,7 @@ function stamp_release(version, varargin)
 %
 % See also: tools/predeploy.sh
 %
-% Phase D3.2 of docs/superpowers/plans/2026-05-20-comprehensive-codebase-audit.md.
+% Introduced for the 2026-05-20 comprehensive codebase audit (Phase D3.2).
 
 parser = inputParser;
 parser.FunctionName = 'tools.stamp_release';
@@ -84,7 +84,7 @@ if exist(notesPath, 'file') == 2
     else
         % prepend a new section after any preamble
         preamble = sprintf('# nSTAT Release Notes\n\n');
-        newSection = sprintf('%s\n\n_Fill in highlights:_\n\n- (correctness fixes)\n- (new capabilities)\n- (breaking changes / deprecations)\n\nSee plans in `docs/superpowers/plans/` and verification reports in `docs/verification/` for details.\n\n---\n\n', ...
+        newSection = sprintf('%s\n\n_Fill in highlights:_\n\n- (correctness fixes)\n- (new capabilities)\n- (breaking changes / deprecations)\n\n---\n\n', ...
             sectionHeader);
         if startsWith(notesText, '# nSTAT Release Notes')
             % insert after the preamble

--- a/tools/verify_all_examples.m
+++ b/tools/verify_all_examples.m
@@ -9,7 +9,7 @@ function results = verify_all_examples(varargin)
 % Runs each script in a captured environment (evalc for stdout, lastwarn
 % for warnings, tic/toc for timing) and emits:
 %   - results table (returned and printed)
-%   - docs/verification/run_report_<timestamp>.json
+%   - run_report_<timestamp>.json (path passed on the command line)
 %   - docs/figures/<script_id>/  (figures captured via findobj snapshot)
 %
 % Phase V0.2 of the 2026-05-20 deep-dive verification plan.


### PR DESCRIPTION
Per owner direction (2026-06-13): `docs/superpowers/` (plans, handoffs) and `docs/verification/` (audit reports) are gitignored. PR #75 added those to `.gitignore` but the entries were dropped (linter/rebase artifact). This PR re-adds them AND scrubs every dangling link to those paths from the public tree.

## What changed

### Re-added to .gitignore

```gitignore
docs/superpowers/
docs/verification/
```

### Scrubbed dangling refs in 19 files

- **User-facing docs**: README.md, RELEASE_NOTES.md, AGENT_GUIDE.md, AUDIT_REPORT.md, CONTRIBUTING.md.
- **Sphinx intro page** (deployed to https://cajigaslab.github.io/nSTAT/): docs/index.md.
- **Source comments / docstrings**: buildfile.m, toolboxOptions.m, tools/check_readme_figures.m, tools/check_bug_patterns.sh, tools/predeploy.sh, tools/stamp_release.m, tools/verify_all_examples.m, tools/audit_help_system.py.
- **Package + helpfile / test inline refs**: +nstat/+decoding/Contents.m, +nstat/+decoding/README.md, helpfiles/WhenToUseWhich.m, tests/unit/testKsUnclamped.m.

### Resolution patterns

- 'see [plan link]' → brief inline description of what the plan accomplished, no link.
- Bibliography-style pointers ('see docs/verification/X.md') → removed; surrounding prose stays.
- 'Plan: ...' comments at file top → 'Introduced in vX.Y for ...'.
- Boilerplate in `stamp_release.m`'s release-notes template → removed 'see docs/superpowers/' instruction.

### Bonus cleanup

- `+nstat/+decoding/README.md` status updated from 'SKELETON ONLY' to 'POPULATED' (the v1.4 cluster classes are all there).
- `buildfile.m` packageTask simplified: the G2-not-yet-landed fallback branch removed since G2 has landed.

## What this PR does NOT do

- Does NOT rewrite history. Tagged releases v1.4.0, v1.4.1, v1.5.0 still link to the plan and verification docs. Browsing the repo at a historical tag will work; browsing at master HEAD has no references to gitignored paths.
- Does NOT republish the helpfile HTML siblings. `WhenToUseWhich.html` still has a stale ref; will rebuild on next `publish_all_helpfiles` invocation.

## Verification

`git grep -E 'docs/(superpowers|verification)'` against the non-gitignored, non-helpfiles-HTML scope returns one result: the intentional write path in `tools/predeploy.sh:100` for the gitignored bug-pattern-audit snapshot.