### PR TITLE
fix(parity-audit): revert #90 PPLFP_Decode_update edit; add EStep-level integration test

### DIFF
--- a/+nstat/+decoding/PPLFP.m
+++ b/+nstat/+decoding/PPLFP.m
@@ -325,11 +325,12 @@ classdef PPLFP
  gamma = zeros(size(mu))';
  end
  if(strcmp(fitType,'binomial'))
- % FIX (#90): every HkAll builder stores cells on the 3rd axis,
- % shape (K_time, hist_cols, numCells). Indexing HkAll(:,:,time_index)
- % treats the 3rd axis as time and throws when numCells != K_time.
- % Slice the correct axis instead.
- Histterm = squeeze(HkAll(time_index,:,:));
+ % NB (#95 — reverted #90 here): PPLFP_EStep pre-permutes HkAll via
+ % `Histtermperm = permute(HkAll, [2 3 1])` before passing it in, so
+ % the third axis of the tensor reaching this function is time, not
+ % cells. The original slice was correct; #90's "fix" was made at the
+ % wrong end of the call chain and is reverted.
+ Histterm = HkAll(:,:,time_index);
  if(size(Histterm,1)~=numCells) %make sure Histterm has proper orientation
  Histterm = Histterm';
  end
@@ -353,8 +354,8 @@ classdef PPLFP
 % tempVec((tempVec>1))=1;
  sumValMat = (repmat(tempVec,size(beta,1),1).*beta)*beta';
  elseif(strcmp(fitType,'poisson'))
- % FIX (#90): same axis-mismatch as the binomial branch above.
- Histterm = squeeze(HkAll(time_index,:,:));
+ % NB (#95 — reverted #90 here): see the binomial branch above.
+ Histterm = HkAll(:,:,time_index);
  if(size(Histterm,1)~=numCells) %make sure Histterm has proper orientation
  Histterm = Histterm';
  end

--- a/tests/unit/testParityAuditJun19Fixes.m
+++ b/tests/unit/testParityAuditJun19Fixes.m
@@ -1,49 +1,59 @@
 classdef testParityAuditJun19Fixes < matlab.unittest.TestCase
-    %TESTPARITYAUDITJUN19FIXES regression tests for the four parity-audit
-    % bug reports filed 2026-06-19 (issues #90, #91, #92, #93).
+    %TESTPARITYAUDITJUN19FIXES regression tests for the parity-audit bugs
+    % filed 2026-06-19 (issues #91, #92, #93) plus an EStep-level
+    % integration test added 2026-06-19 in response to #95.
     %
-    % Each test asserts the failing-input case the issue described now
-    % succeeds (or fails with a clear error, for #92).
+    % #90 (PPLFP HkAll axis) is intentionally NOT covered by a unit test
+    % targeting PPLFP_Decode_update directly: the function expects its
+    % HkAll argument pre-permuted by PPLFP_EStep (time on dim 3); calling
+    % it with raw HkAll tests a calling convention nothing in the codebase
+    % actually uses. Instead, testPPLFP_EStep_endToEnd_nonSquareDN below
+    % exercises the EStep -> Decode_update handshake the way production
+    % code does. That is the test that would have caught PR #94's #95
+    % regression.
 
     methods (Test)
 
-        function testPPLFP_Decode_update_acceptsNonSquareDN(tc)
-            %#90 PPLFP_Decode_update: HkAll(:,:,time_index) used to throw
-            % when numCells != K_time. Build a minimal valid HkAll with
-            % numCells=2, K_time=5 and exercise the update step.
+        function testPPLFP_EStep_endToEnd_nonSquareDN(tc)
+            %#95 PPLFP_EStep -> PPLFP_Decode_update axis handshake.
+            % EStep pre-permutes HkAll so time is on dim 3 before passing
+            % to Decode_update; an axis "fix" at the consumer broke this
+            % handshake in PR #94. Reproduce the exact failing input from
+            % the issue (numCells=2, K=30, non-square) and assert the
+            % poisson chain completes without dimension-mismatch errors.
+            %
+            % HkAll is shaped the way PPLFP_EM builds it when windowTimes
+            % is empty: zeros(1,1,numCells), 3D so the downstream
+            % permute() and slice() flow.
+            %
+            % The binomial branch is NOT exercised here -- it has an
+            % unrelated self-clobbering typo at PPLFP.m:2147
+            % (`HkPerm = HkPerm(:,:,k)` instead of `Hk = HkPerm(:,:,k)`)
+            % that predates PR #94. Filed separately.
+            rng(0, 'twister');
             numCells = 2;
-            K_time   = 5;
-            hist_cols = 1;
-            HkAll = zeros(K_time, hist_cols, numCells);   % builder convention
-            % single spike per cell -- arbitrary values, the test is about
-            % whether sizes flow without index-out-of-bounds errors.
-            HkAll(3,1,1) = 1;
-            HkAll(2,1,2) = 1; HkAll(5,1,2) = 1;
-            dN  = [0 0 1 0 0; 0 1 0 0 1];   % (numCells x K_time)
-            stateDim = 1;
-            x_p = zeros(stateDim,1);
-            W_p = eye(stateDim);
-            C   = zeros(0,stateDim);
-            R   = zeros(0,0);
-            y   = zeros(0,K_time);
-            alpha = zeros(0,1);
-            mu    = zeros(numCells,1);
-            beta  = zeros(stateDim,numCells);
-            gamma = zeros(hist_cols,numCells);
+            K        = 30;
+            delta    = 0.01;
+            stateDim = 2;
 
-            % Run for the time index that previously exceeded the third axis.
-            time_index = 5;
-            tc.verifyWarningFree( @() ...
-                nstat.decoding.PPLFP.PPLFP_Decode_update(x_p, W_p, C, R, ...
-                    y, alpha, dN, mu, beta, 'binomial', gamma, HkAll, ...
-                    time_index, []), ...
-                'PPLFP_Decode_update should accept non-square dN after #90 fix');
+            A   = eye(stateDim);
+            Q   = 1e-3*eye(stateDim);
+            C   = eye(stateDim);
+            R   = 1e-2*eye(stateDim);
+            x0  = zeros(stateDim,1);
+            Px0 = eye(stateDim);
+            y      = zeros(stateDim, K);
+            alpha  = zeros(stateDim, 1);
+            mu     = zeros(numCells, 1);
+            beta   = zeros(stateDim, numCells);
+            gamma  = 0;
+            HkAll  = zeros(K, 1, numCells);   % matches EM's with-windowTimes shape
+            dN     = double(rand(numCells, K) < 0.1);
 
             tc.verifyWarningFree( @() ...
-                nstat.decoding.PPLFP.PPLFP_Decode_update(x_p, W_p, C, R, ...
-                    y, alpha, dN, mu, beta, 'poisson', gamma, HkAll, ...
-                    time_index, []), ...
-                'PPLFP_Decode_update poisson branch should also accept non-square dN');
+                nstat.decoding.PPLFP.PPLFP_EStep(A, Q, C, R, y, alpha, ...
+                    dN, mu, beta, 'poisson', delta, gamma, HkAll, x0, Px0), ...
+                'PPLFP_EStep poisson path must complete on non-square dN (#95)');
         end
 
         function testPPHybridFilterSignatureNamesMU_u(tc)


### PR DESCRIPTION
Closes #95. PR #94 introduced a regression at PPLFP_Decode_update by reading the function as a standalone unit and missing the \`permute\` hop one level up the call chain.

## What broke
\`PPLFP_DecodeLinear\` at line 277 pre-permutes \`HkAll\` before calling \`PPLFP_Decode_update\`:

\`\`\`matlab
Histtermperm = permute(HkAll, [2 3 1]);
...
PPLFP_Decode_update(..., Histtermperm, n, []);  %expects History with time on 3rd index
\`\`\`

The inline comment was self-documenting: **after permute, the third axis is time, not cells.** PR #94's edit at lines 328 / 352 — \`squeeze(HkAll(time_index,:,:))\` — assumed third axis = cells, which is the unpermuted layout. That broke any input where \`numCells != K_time\` was reached via the EStep → DecodeLinear → Decode_update flow.

## What this PR does
1. **Revert** lines 328 and 357 (binomial + poisson branches) back to \`HkAll(:,:,time_index)\`. New \`% NB (#95)\` comments document the EStep → DecodeLinear → Decode_update convention.
2. **Replace the regression test.** \`testPPLFP_Decode_update_acceptsNonSquareDN\` (added in PR #94) called Decode_update directly with raw build-convention \`HkAll\` — a calling convention no real caller uses. Replaced with \`testPPLFP_EStep_endToEnd_nonSquareDN\`, which exercises the production handshake (EStep → DecodeLinear → Decode_update) on the exact failing input from issue #95.

## Notes
- A separate latent typo lives at \`PPLFP.m:2147\` in the binomial branch of EStep's post-filter accumulator: \`HkPerm = HkPerm(:,:,k)\` self-clobbers the tensor. **Predates PR #94.** Will file separately. The new test only exercises the poisson branch.
- The other three PR #94 fixes (#91 PPHybridFilter \`MU_u\` rename, #92 CIF \`Xnames\` validator, #93 SignalObj \`crosscorr\` name-value) are unaffected and stay shipped.
- **#90's original premise looks like a mis-diagnosis.** The reporter's reproduction was theoretical ("v11 iter 49 was blocked"), not an actual stack trace. Their proposed fix (\`K = size(dN,2)\` at line 1612) would have broken the outer cell-loop. My consumer-side fix was wrong too. The original \`HkAll(:,:,time_index)\` slice on the permuted tensor was correct end-to-end, and the new integration test in this PR confirms it. Recommend leaving #90 closed.

## Test gates
| Gate | Result |
|---|---|
| \`tools/run_unit_tests.sh\` (incl. new EStep integration test) | **77 / 77 pass** |
| \`tests/TestParityAgainstBaseline.m\` (legacy + modern) | numeric + plots **PASS** |