### PR TITLE
fix(PPLFP): repair self-clobbering typo in EStep binomial accumulator

### DIFF
--- a/+nstat/+decoding/PPLFP.m
+++ b/+nstat/+decoding/PPLFP.m
@@ -2145,8 +2145,12 @@ classdef PPLFP
  sumPPll=0;
  HkPerm = permute(HkAll,[2 3 1]);
  for k=1:K
-% Hk=squeeze(HkAll(k,:,:)); 
- HkPerm = HkPerm(:,:,k);
+% Hk=squeeze(HkAll(k,:,:));
+ % FIX: was `HkPerm = HkPerm(:,:,k)`, a self-clobbering typo that
+ % shrank HkPerm after the first iteration and then read an
+ % unassigned `Hk` on the next size check. The poisson branch
+ % above has the correct form.
+ Hk = HkPerm(:,:,k);
  if(size(Hk,1)==numCells)
  Hk = Hk';
  end

--- a/tests/unit/testParityAuditJun19Fixes.m
+++ b/tests/unit/testParityAuditJun19Fixes.m
@@ -54,6 +54,16 @@ classdef testParityAuditJun19Fixes < matlab.unittest.TestCase
                 nstat.decoding.PPLFP.PPLFP_EStep(A, Q, C, R, y, alpha, ...
                     dN, mu, beta, 'poisson', delta, gamma, HkAll, x0, Px0), ...
                 'PPLFP_EStep poisson path must complete on non-square dN (#95)');
+
+            % Binomial branch was previously broken by an unrelated
+            % self-clobbering typo at PPLFP.m:2149
+            % (`HkPerm = HkPerm(:,:,k)` instead of `Hk = HkPerm(:,:,k)`).
+            % Fixed alongside the #95 revert -- now both branches must
+            % run end-to-end on the same input.
+            tc.verifyWarningFree( @() ...
+                nstat.decoding.PPLFP.PPLFP_EStep(A, Q, C, R, y, alpha, ...
+                    dN, mu, beta, 'binomial', delta, gamma, HkAll, x0, Px0), ...
+                'PPLFP_EStep binomial path must complete on non-square dN (typo at PPLFP.m:2149)');
         end
 
         function testPPHybridFilterSignatureNamesMU_u(tc)


### PR DESCRIPTION
Companion to PR #96 / issue #95. PR #96's notes flagged a latent typo at \`PPLFP.m:2149\` in the binomial branch of \`PPLFP_EStep\`'s post-filter log-likelihood accumulator:

\`\`\`matlab
% before:
HkPerm = HkPerm(:,:,k);    % self-clobber: HkPerm becomes 2D after iter 1
if(size(Hk,1)==numCells)   % Hk was never assigned
    Hk = Hk';
end

% after:
Hk = HkPerm(:,:,k);
if(size(Hk,1)==numCells)
    Hk = Hk';
end
\`\`\`

The poisson branch (lines 2115-2143) shows the correct form.

## Effect of the typo
Any \`PPLFP_EM\` run with \`fitType='binomial'\` would error in the post-filter \`sumPPll\` accumulation. The branch was effectively dead code; it survived because the parity baseline corpus and helpfile examples exercise only the poisson path.

## What this PR does
1. **One-character fix** — assign \`Hk\`, not \`HkPerm\`. Comment documents why.
2. **Extended regression test** — \`testPPLFP_EStep_endToEnd_nonSquareDN\` now asserts both poisson and binomial paths complete on the same input. This would have caught the typo at the time of any prior #94-style change.

## Test gates
| Gate | Result |
|---|---|
| \`tools/run_unit_tests.sh\` (incl. new binomial assertion) | **77 / 77 pass** |
| \`tests/TestParityAgainstBaseline.m\` (legacy + modern) | numeric + plots **PASS** |