### PR TITLE
fix(parity-audit): PPLFP_EM scalar-gamma guard + matlabpool modernization (#98, #99)

### DIFF
--- a/+nstat/+decoding/PPLFP.m
+++ b/+nstat/+decoding/PPLFP.m
@@ -632,7 +632,9 @@ classdef PPLFP
  
  IBetaComp =zeros(size(xKFinal,1)*numCells,size(xKFinal,1)*numCells);
  xkPerm = permute(xKDrawExp,[1 3 2]);
- pools = matlabpool('size'); %number of parallel workers
+ % FIX (#99): matlabpool was removed in R2017a. Modern equivalent is
+ % gcp('nocreate'), which returns the current pool or [] if none.
+ ppPool = gcp('nocreate'); if isempty(ppPool), pools = 0; else, pools = ppPool.NumWorkers; end
  if(pools==0)
  if(strcmp(fitType,'poisson'))
  for c=1:numCells
@@ -1059,7 +1061,8 @@ classdef PPLFP
 
  IMc = zeros(nTerms,nTerms,Mc);
  % Emperically estimate the covariance of the score
- pools = matlabpool('size'); %number of parallel workers 
+ % FIX (#99): matlabpool was removed in R2017a; see note at line 635.
+ ppPool = gcp('nocreate'); if isempty(ppPool), pools = 0; else, pools = ppPool.NumWorkers; end
  if(pools==0) % parallel toolbox is not enabled;
  for c=1:Mc
  x_K=xKDraw(:,:,c);
@@ -1596,10 +1599,17 @@ classdef PPLFP
  end
  
  if(nargin<13 || isempty(windowTimes))
- if(isempty(gamma))
+ % FIX (#98): a scalar gamma==0 should be treated the same as
+ % isempty(gamma) -- "no history". The previous guard only checked
+ % isempty(), so callers passing gamma=0 + windowTimes=[] tripped
+ % the else branch, which inferred 2 history windows from
+ % length(scalar)+1 and built HkAll with hist_cols=2. The scalar
+ % gamma was then broadcast to (1, numCells) in Decode_update and
+ % failed the matmul against a (numCells, 2) Histterm.
+ if(isempty(gamma) || (isscalar(gamma) && gamma == 0))
  windowTimes =[];
  else
- % numWindows =length(gamma0)+1; 
+ % numWindows =length(gamma0)+1;
  windowTimes = 0:delta:(length(gamma)+1)*delta;
  end
  end
@@ -1626,10 +1636,14 @@ classdef PPLFP
  HkAll(:,:,k) = histObj.computeHistory(nst{k}).dataToMatrix;
  end
  else
- for k=1:K
-% HkAll{k} = 0;
- HkAll(:,:,k) = 0;
- end
+ % FIX (#98): the original `HkAll(:,:,k) = 0` loop sized HkAll as
+ % (1, 1, K) where K=numCells. After PPLFP_DecodeLinear's
+ % `permute([2 3 1])` that collapses to a 2D (1, numCells) array,
+ % and Decode_update's `HkAll(:,:,time_index)` for time_index > 1
+ % goes out of bounds. Size HkAll to match the with-windowTimes
+ % shape: (K_time, 1, numCells). gamma=0 still kills the history
+ % contribution at line 369.
+ HkAll = zeros(size(dN, 2), 1, K);
  gamma=0;
  end
 
@@ -2369,7 +2383,8 @@ classdef PPLFP
  xKDrawExp(:,k,:)=repmat(x_K(:,k),[1 McExp])+(chol_m*z);
  end
  % Stimulus Coefficients
- pool = matlabpool('size');
+ % FIX (#99): matlabpool was removed in R2017a; see note at line 635.
+ ppPool = gcp('nocreate'); if isempty(ppPool), pool = 0; else, pool = ppPool.NumWorkers; end
  if(pool==0)
  xkPerm = permute(xKDrawExp,[1 3 2]);
  for c=1:numCells

--- a/+nstat/+decoding/PointProcessEM.m
+++ b/+nstat/+decoding/PointProcessEM.m
@@ -210,7 +210,8 @@ classdef PointProcessEM
  
  IBetaComp =zeros(size(xKFinal,1)*numCells,size(xKFinal,1)*numCells);
  xkPerm = permute(xKDrawExp,[1 3 2]);
- pools = matlabpool('size'); %number of parallel workers 
+ % FIX (#99): matlabpool was removed in R2017a; same defect class as PPLFP.m.
+ ppPool = gcp('nocreate'); if isempty(ppPool), pools = 0; else, pools = ppPool.NumWorkers; end
  if(strcmp(fitType,'poisson'))
  for c=1:numCells
  HessianTerm = zeros(size(xKFinal,1),size(xKFinal,1),K);
@@ -567,7 +568,8 @@ classdef PointProcessEM
 
  IMc = zeros(nTerms,nTerms,Mc);
  % Emperically estimate the covariance of the score
- pools = matlabpool('size'); %number of parallel workers 
+ % FIX (#99): matlabpool was removed in R2017a; same defect class as PPLFP.m.
+ ppPool = gcp('nocreate'); if isempty(ppPool), pools = 0; else, pools = ppPool.NumWorkers; end
  if(pools==0) % parallel toolbox is not enabled;
  for c=1:Mc
  x_K=xKDraw(:,:,c);
@@ -2154,7 +2156,8 @@ classdef PointProcessEM
  end
  
  % Stimulus Coefficients
- pool = matlabpool('size');
+ % FIX (#99): matlabpool was removed in R2017a; same defect class as PPLFP.m.
+ ppPool = gcp('nocreate'); if isempty(ppPool), pool = 0; else, pool = ppPool.NumWorkers; end
  if(pool==0)
  for c=1:numCells
  converged=0;

--- a/tests/unit/testParityAuditJun19Fixes.m
+++ b/tests/unit/testParityAuditJun19Fixes.m
@@ -107,5 +107,66 @@ classdef testParityAuditJun19Fixes < matlab.unittest.TestCase
                 'SignalObj.autocorrelation must accept newer crosscorr API (#93)');
         end
 
+        function testPPLFP_EM_handlesScalarGammaNoWindow(tc)
+            %#98 Regression: PPLFP_EM with gamma=0 (scalar) and
+            % windowTimes=[] previously triggered the windowTimes-
+            % construction guard, which inferred 2 history windows from
+            % length(scalar)+1 and built HkAll with hist_cols=2. The
+            % scalar gamma was then broadcast to (1, numCells) in
+            % Decode_update and matmul-failed against a (numCells, 2)
+            % Histterm. The fix treats `isscalar(gamma) && gamma==0` as
+            % the no-history signal.
+            rng(0, 'twister');
+            numCells = 2; K = 30; delta = 0.01; stateDim = 2;
+            A = eye(stateDim);  Q = 1e-3*eye(stateDim);
+            C = eye(stateDim);  R = 1e-2*eye(stateDim);
+            Px0 = eye(stateDim); x0 = zeros(stateDim,1);
+            y = zeros(stateDim, K);   alpha = zeros(stateDim, 1);
+            mu = zeros(numCells, 1);  beta = zeros(stateDim, numCells);
+            gamma = 0;                windowTimes = [];
+            dN = double(rand(numCells, K) < 0.1);
+            EM_C = nstat.decoding.PPLFP.PPLFP_EMCreateConstraints();
+
+            % EM runs through the matmul site at PPLFP_Decode_update:369
+            % during iteration 1. If a downstream error (e.g. the
+            % plotting-related defect at PPLFP_EM:1810) trips later,
+            % that is outside the scope of #98; we only assert the
+            % matmul error is no longer raised.
+            try
+                nstat.decoding.PPLFP.PPLFP_EM(y, dN, A, Q, C, R, alpha, ...
+                    mu, beta, 'poisson', delta, gamma, windowTimes, ...
+                    x0, Px0, EM_C, []);
+            catch ME
+                tc.verifyNotEqual(ME.identifier, 'MATLAB:innerdim', ...
+                    sprintf(['PPLFP_EM must not raise MATLAB:innerdim ' ...
+                             'when gamma=0 + windowTimes=[] (#98). ' ...
+                             'Actual error: %s at %s line %d'], ...
+                            ME.identifier, ME.stack(1).name, ME.stack(1).line));
+            end
+        end
+
+        function testNoLiveMatlabpoolCalls(tc)
+            %#99 matlabpool was removed in R2017a; gcp('nocreate') is the
+            % modern equivalent. Tripwire: scan the decoding package
+            % source for any non-commented matlabpool( call. Fails if
+            % future changes re-introduce the deprecated API.
+            repoRoot = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+            files = {
+                fullfile(repoRoot,'+nstat','+decoding','PPLFP.m')
+                fullfile(repoRoot,'+nstat','+decoding','PointProcessEM.m')
+                };
+            for k = 1:numel(files)
+                txt = fileread(files{k});
+                lines = strsplit(txt, newline);
+                for ln = 1:numel(lines)
+                    line = strtrim(lines{ln});
+                    if isempty(line) || startsWith(line, '%'); continue; end
+                    tc.verifyEmpty(regexp(line, 'matlabpool\(', 'once'), ...
+                        sprintf('%s line %d still calls matlabpool() -- use gcp(''nocreate'') (#99)', ...
+                                files{k}, ln));
+                end
+            end
+        end
+
     end
 end


### PR DESCRIPTION
Closes #98 and #99 from the 2026-06-19 parity-audit ledger.

## #98 — \`PPLFP_EM\` matmul mismatch was caused by the wrong layer
Reproduced. Stack trace went to \`PPLFP_Decode_update:369\` (the matmul) but the **actual bug** is at the top of \`PPLFP_EM\` (lines 1601-1614):

\`\`\`matlab
% before:
if(nargin<13 || isempty(windowTimes))
    if(isempty(gamma))          % scalar 0 is NOT empty
        windowTimes = [];
    else
        windowTimes = 0:delta:(length(gamma)+1)*delta;   % synthesizes 2 windows from scalar
    end
end
\`\`\`

Caller passes \`gamma=0\` (scalar) + \`windowTimes=[]\` → guard infers 2 history windows from \`length(scalar)+1\` → EM takes the with-history path → builds \`HkAll\` with \`hist_cols=2\` → \`Decode_update\` slices a \`(2,2)\` \`Histterm\` → scalar gamma auto-broadcast to \`(1, numCells)\` → \`gamma' * Histterm'\` is \`(2,1) * (2,2)\` → **inner-dim mismatch**.

Fix: treat \`isscalar(gamma) && gamma==0\` the same as \`isempty(gamma)\`. Verified end-to-end with the issue's exact input (\`dN = rand(2,30) < 0.1\`): \`PPLFP_EM\` now completes 2 full iterations and produces a finite \`logll\` before tripping on an unrelated downstream plotting defect (separate issue).

A secondary defect in the same \`else\` branch is also patched: the no-history HkAll init was \`zeros(1,1,numCells)\`, which after the downstream \`permute([2 3 1])\` collapses to a 2D \`(1, numCells)\` array and fails the time-axis slice. Sized to match the with-windowTimes shape: \`(K_time, 1, numCells)\`.

## #99 — \`matlabpool\` removed in R2017a
Six live sites swapped to \`gcp('nocreate')\` across two files (issue flagged three; audit-sweep found three more in \`PointProcessEM\` with the same pattern):

| File | Lines |
|---|---|
| \`+nstat/+decoding/PPLFP.m\` | 635, 1064, 2375 |
| \`+nstat/+decoding/PointProcessEM.m\` | 213, 570, 2159 |

Standard replacement:
\`\`\`matlab
ppPool = gcp('nocreate');
if isempty(ppPool), pools = 0; else, pools = ppPool.NumWorkers; end
\`\`\`

Tripwire test scans both files for any non-commented \`matlabpool(\` call; fails if a future change re-introduces the deprecated API.

## Test gates
| Gate | Result |
|---|---|
| \`tools/run_unit_tests.sh\` (incl. 2 new regression tests) | **79 / 79 pass** (was 77) |
| \`tests/TestParityAgainstBaseline.m\` (legacy + modern) | numeric + plots **PASS** |