### PR TITLE
fix(helpfile): xticklabel_rotate -> xtickangle; brace-indexing on FitResult (#102)

### DIFF
--- a/helpfiles/ExplicitStimulusWhiskerData.m
+++ b/helpfiles/ExplicitStimulusWhiskerData.m
@@ -75,8 +75,12 @@ cRef = TrialConfig({{'Baseline','constant'}},sampleRate,[],[]);
 cRef.setName('BaselineRef');
 trialRef = Trial(nspikeColl, CovColl({baseline}));
 resRef   = Analysis.RunAnalysisForAllNeurons(trialRef, ConfigColl({cRef}), 0);
-AICref = resRef{1}.AIC;
-BICref = resRef{1}.BIC;
+% FIX (#102): RunAnalysisForAllNeurons returns a FitResult OBJECT for the
+% single-neuron / single-config case, not a cell. The {1} brace-indexing
+% added in #83's scan section errored at publish-time and left the
+% resulting figure blank in the rendered HTML.
+AICref = resRef.AIC;
+BICref = resRef.BIC;
 
 for j = 1:length(candidateLags)
     stim_j  = Covariate(time, stimData, 'Stimulus','time','s','V',{'stim'});
@@ -85,9 +89,10 @@ for j = 1:length(candidateLags)
     cSc = TrialConfig({{'Baseline','constant'},{'Stimulus','stim'}}, sampleRate, [], []);
     cSc.setName(sprintf('lag=%.3gs', candidateLags(j)));
     rj = Analysis.RunAnalysisForAllNeurons(trial_j, ConfigColl({cSc}), 0);
-    ks_scan(j)   = rj{1}.KSStats.ks_stat;
-    dAIC_scan(j) = rj{1}.AIC - AICref;
-    dBIC_scan(j) = rj{1}.BIC - BICref;
+    % FIX (#102): same brace-indexing bug as above (FitResult, not cell).
+    ks_scan(j)   = rj.KSStats.ks_stat;
+    dAIC_scan(j) = rj.AIC - AICref;
+    dBIC_scan(j) = rj.BIC - BICref;
 end
 
 [~, bestIdx] = min(ks_scan);
@@ -179,11 +184,15 @@ end
 
 figure;
 plot(x,dBIC,'.');
+ylabel('\Delta BIC'); xlabel('history window');
 xticks = 1:(length(histLabels));
 set(gca,'xtick',xticks,'xtickLabel',histLabels,'FontSize',6);
-if(max(xticks)>=1)
-    xticklabel_rotate([],90,[],'Fontsize',8);
-end
+% FIX (#102): xticklabel_rotate is a File Exchange helper that manipulates
+% the figure's Position/axes in a way that publish() renders as a near-blank
+% PNG. xtickangle is a built-in equivalent (R2014b+) that works cleanly
+% under publish().
+xtickangle(90);
+set(gca,'FontSize',8);
            
 
 %% Compare Baseline, Baseline+Stimulus Model, Baseline+History+Stimulus


### PR DESCRIPTION
Closes #102. Two source-level defects in \`helpfiles/ExplicitStimulusWhiskerData.m\` that the v14 parity-audit image-pair validation flagged as causing near-blank publish() output.

## Fix 1 — \`xticklabel_rotate\` → \`xtickangle\`
Line 185 used the File Exchange helper \`xticklabel_rotate\`, which manipulates the figure's \`Position\`/axes in a way \`publish()\` renders as near-blank. \`xtickangle\` is the R2014b+ built-in equivalent.

## Fix 2 — brace-indexing a FitResult object
**Latent bug I introduced in PR #89** for #83's stimulus-lag scan. The scan loop indexes \`Analysis.RunAnalysisForAllNeurons\`'s return as a cell:

\`\`\`matlab
AICref = resRef{1}.AIC;       % errors -- resRef is a FitResult, not a cell
rj      = Analysis.RunAnalysisForAllNeurons(trial_j, ConfigColl({cSc}), 0);
ks_scan(j)   = rj{1}.KSStats.ks_stat;
\`\`\`

\`RunAnalysisForAllNeurons\` returns a **\`FitResult\` object** for the single-neuron / single-config case. Removed the \`{1}\` at all 5 sites.

### Why PR #89's smoke test missed this
PR #89's smoke test invoked \`run('ExplicitStimulusWhiskerData')\` from inside an \`evalin('base', ...)\` wrapper. MATLAB's name resolution prefers \`.mlx\` over \`.m\` when both exist, so \`run()\` actually executed the **pre-edit \`.mlx\`**, not the freshly-edited \`.m\`. The shadow-execution masked the bug. A future tooling hardening would be to delete-or-rename the \`.mlx\` before smoke-testing the \`.m\`. Out of scope here.

## Why this PR does NOT commit regenerated \`.mlx\` / \`.html\` / PNGs

Both \`export(mlxFile, htmlFile, 'Run', true)\` and \`publish(mFile, ...)\` fail mid-script on R2025b at:

\`\`\`
Analysis.computeHistLag:1181 -> Analysis.RunAnalysisForNeuron:123
  -> Analysis.GLMFit:541 -> Trial.getDesignMatrix:481   (concatenation dim mismatch)
\`\`\`

That site is in the history-lag scan section (helpfile line 132), unrelated to the two source bugs above. Running \`publish()\` against the fixed \`.m\` produced only 4 of 10 figures, four of which were identically-sized 20K blank error-placeholders — **strictly worse than the committed Jun-11 PNGs**. The committed artifacts therefore stay unchanged. Future re-publish is blocked on the upstream concat issue; will file separately.

## Test gates
| Gate | Result |
|---|---|
| \`tools/run_unit_tests.sh\` | **79 / 79 pass** |
| Partial-bisect smoke through line 96 (covers my scan section) | PASS |
| Full helpfile run | blocked on pre-existing downstream \`Trial.getDesignMatrix\` defect (out of scope) |