### PR TITLE
fix(helpfile): drop orphan figure; that left DecodingExample_03.png blank + verify-artifacts policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,18 @@ matlab.internal.liveeditor.openAndSave( ...
 
 Commit the `.m` first, the regenerated `.mlx` second — they should diff as a paired update.
 
+### Verifying regenerated `.mlx` / `.html` / PNG artifacts before commit
+
+Regenerating the rendered helpfile docs (`.mlx`, `.html`, per-figure PNGs) is *not* a mechanical follow-up — the rendered artifacts can silently degrade vs the committed baseline, and the committed copies under `helpfiles/` are what GitHub serves to users. PR #88/#89/#103 → PR #105 (rollback) is a case where the regeneration looked successful at the function level but produced a measurably worse `.html` than the pre-edit baseline.
+
+Before committing any regenerated artifact, run these three checks:
+
+1. **Byte-size diff per file.** `git diff --stat HEAD -- helpfiles/` should show *plausible* size deltas: a `.mlx` jumping 50×, or PNGs landing at identical byte counts (signature of blank placeholders), are both red flags. If unsure, compare to the previous run: `git show HEAD:helpfiles/Foo_03.png | wc -c` vs `wc -c helpfiles/Foo_03.png`.
+2. **Open the rendered `.html` in a browser.** Confirm each figure block contains the expected plot — not an error placeholder, not a blank axes frame. A `publish` / `export` that errored mid-script will still emit valid-but-empty figures and a tiny HTML body; size and visual inspection both catch this.
+3. **Bisect on script position.** If the helpfile's full run errors (e.g., latent handle-sharing pollution that only surfaces deep in the script), bisect with `strjoin(lines(1:ep), newline)` snippets at section boundaries (after `end` of loops, after `;` of complete statements) to localize the failing site *before* asking `publish` or `export` to render anything. Bisecting catches the failure on the source side, not the artifact side.
+
+If any check fails, **`git restore helpfiles/*` and ship only the `.m` change.** A stale `.html` rendered against last week's pipeline is not a regression; a regenerated `.html` with fewer or blank figures *is*. PR #103 followed this rule (shipped `.m` only) and PR #105 reverted the *next* PR that didn't.
+
 ## Local test gate
 
 **CI does not run MATLAB.** The team's MathWorks license does not extend to GitHub-hosted runners, so there is no automated MATLAB-test gate on PRs. The local pass is the only test gate.

--- a/helpfiles/DecodingExample.m
+++ b/helpfiles/DecodingExample.m
@@ -42,7 +42,10 @@ c{2} = TrialConfig({{'Baseline','constant'},{'Stimulus','stim'}},...
 c{2}.setName('Baseline+Stimulus');
 cfgColl= ConfigColl(c);
 results = Analysis.RunAnalysisForAllNeurons(trial,cfgColl,0);
-figure;
+% NB: do not pre-create a figure here -- FitResult.plotResults opens its
+% own figure(...) internally. A bare `figure;` immediately before it
+% leaves a blank axes frame that publish() snapshots as a near-empty PNG
+% (was DecodingExample_03.png at ~3.5 KB vs the populated ~126 KB next).
 results{1}.plotResults;
 Summary = FitResSummary(results);
 


### PR DESCRIPTION
Two related changes:

## 1. \`helpfiles/DecodingExample.m\` — drop orphan \`figure;\`

Removed the bare \`figure;\` on line 45. \`FitResult.plotResults\` (called on the next line) opens its own \`figure(...)\` internally — the preceding \`figure;\` left an empty axes frame that \`publish()\` snapshotted as \`DecodingExample_03.png\` at **3,506 bytes**, sitting between two populated figures (28 KB and 126 KB).

I swept the rest of \`helpfiles/*.m\` for the same \`bare figure; → .plotResults/.plotSummary\` antipattern — only DecodingExample.m had it.

\`.m\`-only fix; rendered \`.html\` and PNGs renumber on the next full predeploy publish run (per the verification policy added below).

## 2. \`CONTRIBUTING.md\` — verifying regenerated artifacts before commit

New subsection under the existing \`.m\`-canonical / smoke-testing policy. Encodes the lesson from PR #103 → PR #105 (the rollback): regenerated rendered docs can silently degrade vs the committed baseline, and the committed copies are what GitHub serves. Three pre-commit checks documented:

- **Byte-size deltas** — red flags include a \`.mlx\` jumping 50× or PNGs landing at identical byte counts (blank-placeholder signature).
- **Visual inspection of the rendered \`.html\`** — confirm each figure block actually contains the expected plot.
- **Bisect on script position** when the full run errors, before asking \`publish\`/\`export\` to render anything.

The closing line of the new subsection states the rule explicitly: if any check fails, \`git restore helpfiles/*\` and ship only the \`.m\` change. A stale \`.html\` against last week's pipeline is not a regression; a regenerated \`.html\` with fewer or blank figures **is**.

## Test gates
| Gate | Result |
|---|---|
| \`tools/run_unit_tests.sh\` | **79 / 79 pass** |