### PR TITLE
chore(matlab): switch default to R2026a

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -51,7 +51,7 @@ remains authoritative for reproducing the 2012 paper examples.
 
 ## 2. Requirements
 
-- **MATLAB R2025b** (currently targeted by the install script and parity tests).
+- **MATLAB R2026a** (currently targeted by the install script and parity tests).
  Should run on R2020a+ but Simulink models predate that.
 - **No required toolboxes beyond core MATLAB and Statistics**, *but*:
  - `CIF` uses the **Symbolic Math Toolbox** to build derivative functions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ Adding `matlab-actions/setup-matlab@v2` to a GitHub Actions workflow requires a 
 
 ### Alternative MATLAB versions
 
-Default is `R2025b` at `/Applications/MATLAB_R2025b.app`. Override with either:
+Default is `R2026a` at `/Applications/MATLAB_R2026a.app`. Override with either:
 
 ```bash
 MATLAB_BIN=/Applications/MATLAB_R2024b.app/bin/matlab tools/run_unit_tests.sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ nSTAT is the reference MATLAB implementation of the point-process / state-space 
 ## Install
 
 ```matlab
-% In MATLAB R2025b, from the repository root:
+% In MATLAB R2026a, from the repository root:
 cd('/path/to/nSTAT')
 nSTAT_Install('DownloadExampleData', true);   % auto-fetches the figshare dataset
 ```

--- a/docs/paper_examples.md
+++ b/docs/paper_examples.md
@@ -16,7 +16,7 @@ Paper reference:
 
 ## Run Everything
 
-From a fresh clone (MATLAB R2025b):
+From a fresh clone (MATLAB R2026a):
 
 ```matlab
 cd('/path/to/nSTAT')

--- a/helpfiles/publish_all_helpfiles.m
+++ b/helpfiles/publish_all_helpfiles.m
@@ -89,7 +89,7 @@ function opts = parseOptions(varargin)
 parser = inputParser;
 parser.FunctionName = 'publish_all_helpfiles';
 addParameter(parser, 'EvalCode', true, @(x)islogical(x) || isnumeric(x));
-addParameter(parser, 'ExpectedGenerator', 'MATLAB 25.2', @(x)ischar(x) || isstring(x));
+addParameter(parser, 'ExpectedGenerator', 'MATLAB 26.1', @(x)ischar(x) || isstring(x));
 addParameter(parser, 'BlankPngThresholdBytes', 5000, @(x)isnumeric(x) && isscalar(x) && x >= 0);
 parse(parser, varargin{:});
 

--- a/info.xml
+++ b/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <productinfo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="https://www.mathworks.com/help/schema/productinfo.xsd">
-  <matlabrelease>R2025b</matlabrelease>
+  <matlabrelease>R2026a</matlabrelease>
   <name>nSTAT Neural Spike Train Analysis</name>
   <type>toolbox</type>
   <icon>helpfiles/LogoSmall.png</icon>

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -31,7 +31,7 @@ runtests('tests/integration/testKsAgainstReferenceZoo')
 From the shell:
 
 ```bash
-/Applications/MATLAB_R2025b.app/bin/matlab -batch \
+/Applications/MATLAB_R2026a.app/bin/matlab -batch \
  "addpath(genpath(pwd)); results = runtests('tests/integration'); disp(results); assert(~any([results.Failed]))"
 ```
 

--- a/tools/check_readme_figures.sh
+++ b/tools/check_readme_figures.sh
@@ -25,7 +25,7 @@
 
 set -euo pipefail
 
-MATLAB_BIN="${MATLAB_BIN:-/Applications/MATLAB_R2025b.app/bin/matlab}"
+MATLAB_BIN="${MATLAB_BIN:-/Applications/MATLAB_R2026a.app/bin/matlab}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/tools/predeploy.sh
+++ b/tools/predeploy.sh
@@ -39,7 +39,7 @@
 
 set -uo pipefail
 
-MATLAB_BIN="${MATLAB_BIN:-/Applications/MATLAB_R2025b.app/bin/matlab}"
+MATLAB_BIN="${MATLAB_BIN:-/Applications/MATLAB_R2026a.app/bin/matlab}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 

--- a/tools/run_unit_tests.sh
+++ b/tools/run_unit_tests.sh
@@ -8,7 +8,7 @@
 # only test gate.
 #
 # Usage:
-#   tools/run_unit_tests.sh                  # run tests/unit/ with R2025b
+#   tools/run_unit_tests.sh                  # run tests/unit/ with R2026a
 #   tools/run_unit_tests.sh --integration    # also run tests/integration/
 #   tools/run_unit_tests.sh --matlab-path /Applications/MATLAB_R2024b.app
 #
@@ -22,7 +22,7 @@
 set -euo pipefail
 
 # Default MATLAB binary; override with --matlab-path or MATLAB_BIN env var
-MATLAB_BIN="${MATLAB_BIN:-/Applications/MATLAB_R2025b.app/bin/matlab}"
+MATLAB_BIN="${MATLAB_BIN:-/Applications/MATLAB_R2026a.app/bin/matlab}"
 INCLUDE_INTEGRATION=0
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
10-file MATLAB-version pointer swap. Operational defaults (MATLAB_BIN, ExpectedGenerator, info.xml release tag) and doc references move from R2025b → R2026a. HTML generator tags, manifest.json, RELEASE_NOTES.md, and one historical comment intentionally left alone (refresh via their own pipelines). Smoke: 79/79 unit tests pass; HelloNstat + DecodingExample publish OK under R2026a.