### PR TITLE
chore(tools): promote smoke_helpfile + check_helpfile_drift to tracked tools/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,22 @@ A specific consequence of MATLAB's `.mlx`-over-`.m` resolution: if you edit a he
 
 This is exactly what bit PR #89 (the stimulus-lag scan added to `ExplicitStimulusWhiskerData`, closing issue #83). Its smoke test invoked `run('ExplicitStimulusWhiskerData')` inside an `evalin('base', ...)` wrapper and reported PASS. The runtime had executed the pre-edit `.mlx`. The `.m` contained `resRef{1}.AIC` — brace-indexing a `FitResult` object — which errored at the next render. Surfaced and fixed in PR #103 (issue #102).
 
-When you edit a helpfile `.m` and want a real end-to-end smoke check, use **one** of these patterns so MATLAB resolves to the `.m`:
+When you edit a helpfile `.m` and want a real end-to-end smoke check, the simplest path is the tracked harness:
 
 ```matlab
-% Pattern A — force-resolve via `which`:
+% Pattern A (recommended) — tools/smoke_helpfile.m runs publish() in a
+% staged sandbox (strips any .mlx that would shadow), reports figure
+% count + sizes + blank suspects + delta vs HEAD baseline.
+addpath('tools'); smoke_helpfile('ExplicitStimulusWhiskerData');
+```
+
+For ad-hoc cases or when you want to use `run()` directly, force the `.m` resolution explicitly:
+
+```matlab
+% Pattern B — force-resolve via `which`:
 run(which('helpfiles/ExplicitStimulusWhiskerData.m'));
 
-% Pattern B — temporarily shadow the .mlx:
+% Pattern C — temporarily shadow the .mlx:
 mlxPath  = fullfile('helpfiles', 'ExplicitStimulusWhiskerData.mlx');
 mlxStash = [mlxPath '.shadowed'];
 movefile(mlxPath, mlxStash);
@@ -57,6 +66,19 @@ Commit the `.m` first, the regenerated `.mlx` second — they should diff as a p
 ### Verifying regenerated `.mlx` / `.html` / PNG artifacts before commit
 
 Regenerating the rendered helpfile docs (`.mlx`, `.html`, per-figure PNGs) is *not* a mechanical follow-up — the rendered artifacts can silently degrade vs the committed baseline, and the committed copies under `helpfiles/` are what GitHub serves to users. PR #88/#89/#103 → PR #105 (rollback) is a case where the regeneration looked successful at the function level but produced a measurably worse `.html` than the pre-edit baseline.
+
+The tracked harness for the per-PNG diff is [`tools/check_helpfile_drift.m`](tools/check_helpfile_drift.m). Default comparison is against HEAD-committed PNGs (auto-staged to a temp dir):
+
+```matlab
+% Default: compare current helpfiles/ against HEAD's committed PNGs.
+addpath('tools'); report = check_helpfile_drift;
+
+% Compare against an older worktree that you've already published into
+% (use this when investigating drift vs a historical commit).
+report = check_helpfile_drift('Other', '/tmp/nstat-2017/helpfiles');
+```
+
+Verdict classes mirror `tools/check_readme_figures.m`: `IDENTICAL` / `TINY` / `SUBSTANTIVE` / `DIM_DIFF` / `ONLY_NOW` / `ONLY_OTHER`. The tool also produces a per-helpfile rollup showing where new figures appeared (`NEW`) or 2017-vintage figures disappeared (`LOST`).
 
 Before committing any regenerated artifact, run these three checks:
 

--- a/tools/check_helpfile_drift.m
+++ b/tools/check_helpfile_drift.m
@@ -1,0 +1,184 @@
+function report = check_helpfile_drift(varargin)
+%CHECK_HELPFILE_DRIFT Pixel-diff two helpfile directories.
+%
+% Usage:
+%   % Default: compare current helpfiles/ against HEAD's committed PNGs
+%   % via a temp checkout. Both ends rendered under whatever MATLAB you have.
+%   tools.check_helpfile_drift
+%
+%   % Compare current helpfiles/ against a known good directory
+%   % (e.g., a checkout of an earlier commit you've already published into).
+%   tools.check_helpfile_drift('Other', '/path/to/older/helpfiles')
+%
+% When `Other` is supplied, the two directories should have been
+% generated under the same MATLAB version -- otherwise the comparison is
+% dominated by rendering-environment noise (DIM_DIFF verdicts) instead of
+% real source-side drift. See the PR #109 investigation for context: the
+% 2017 source under R2026a comparison was created exactly this way after
+% the naive 2017-committed-PNGs comparison turned out to be unusable.
+%
+% Verdict classes (mirrors tools/check_readme_figures.m):
+%   IDENTICAL    byte-equal
+%   TINY         mean abs delta < TinyThreshold (default 0.5)
+%   SUBSTANTIVE  mean abs delta >= TinyThreshold
+%   DIM_DIFF     pixel dimensions differ (rendering env mismatch)
+%   ONLY_NOW     in helpDir but not Other (new since baseline)
+%   ONLY_OTHER   in Other but not helpDir (lost relative to baseline)
+%   READ_ERROR   imread failed
+%
+% Output: per-PNG struct array with name/kind/mad/sizes/helpfile.
+%
+% Introduced after PR #109 to make the "current vs older-source"
+% comparison reproducible without recreating the harness in /tmp.
+
+p = inputParser;
+p.FunctionName = 'tools.check_helpfile_drift';
+addParameter(p, 'HelpDir', '', @(x) ischar(x) || isstring(x));
+addParameter(p, 'Other', '', @(x) ischar(x) || isstring(x));
+addParameter(p, 'TinyThreshold', 0.5, @(x) isnumeric(x) && isscalar(x) && x >= 0);
+parse(p, varargin{:});
+opts = p.Results;
+
+repoRoot = fileparts(fileparts(mfilename('fullpath')));
+if isempty(opts.HelpDir)
+    helpDir = fullfile(repoRoot, 'helpfiles');
+else
+    helpDir = char(string(opts.HelpDir));
+end
+if isempty(opts.Other)
+    % Default: stage HEAD-committed helpfiles to a temp directory for comparison.
+    fprintf('Other not supplied; staging HEAD helpfiles to a temp directory...\n');
+    otherDir = stageHeadHelpfiles(repoRoot);
+    cleanupOther = onCleanup(@() tryRmdir(otherDir)); %#ok<NASGU>
+else
+    otherDir = char(string(opts.Other));
+end
+
+nowSet = listPngsAsMap(helpDir);
+oldSet = listPngsAsMap(otherDir);
+allNames = unique([keys(nowSet), keys(oldSet)]);
+fprintf('Comparing %d unique PNG names (helpDir=%s, other=%s)...\n', ...
+    numel(allNames), helpDir, otherDir);
+
+rows = struct('name',{},'kind',{},'mad',{},'now_bytes',{},'other_bytes',{},'helpfile',{});
+for k = 1:numel(allNames)
+    nm = allNames{k};
+    inNow = nowSet.isKey(nm);
+    inOld = oldSet.isKey(nm);
+    helpfilePrefix = regexprep(nm, '_\d+\.png$|\.png$', '');
+    if inOld && ~inNow
+        rows(end+1,1) = struct('name',nm,'kind','ONLY_OTHER','mad',NaN, ...
+            'now_bytes',0,'other_bytes',oldSet(nm).bytes,'helpfile',helpfilePrefix); %#ok<AGROW>
+    elseif inNow && ~inOld
+        rows(end+1,1) = struct('name',nm,'kind','ONLY_NOW','mad',NaN, ...
+            'now_bytes',nowSet(nm).bytes,'other_bytes',0,'helpfile',helpfilePrefix); %#ok<AGROW>
+    else
+        nowP = fullfile(helpDir, nm);
+        oldP = fullfile(otherDir, nm);
+        try; a = imread(nowP); catch; a = []; end
+        try; b = imread(oldP); catch; b = []; end
+        if isempty(a) || isempty(b)
+            kind = 'READ_ERROR'; mad = NaN;
+        elseif ~isequal(size(a), size(b))
+            kind = 'DIM_DIFF'; mad = NaN;
+        else
+            mad = mean(abs(double(a(:)) - double(b(:))));
+            if mad == 0
+                kind = 'IDENTICAL';
+            elseif mad < opts.TinyThreshold
+                kind = 'TINY';
+            else
+                kind = 'SUBSTANTIVE';
+            end
+        end
+        rows(end+1,1) = struct('name',nm,'kind',kind,'mad',mad, ...
+            'now_bytes',nowSet(nm).bytes,'other_bytes',oldSet(nm).bytes,'helpfile',helpfilePrefix); %#ok<AGROW>
+    end
+end
+
+% Tally
+kinds = {rows.kind};
+fprintf('\n=== Verdict tally ===\n');
+uk = unique(kinds);
+for k = 1:numel(uk)
+    fprintf('  %-15s %4d\n', uk{k}, sum(strcmp(kinds, uk{k})));
+end
+
+% SUBSTANTIVE detail
+subIdx = find(strcmp(kinds, 'SUBSTANTIVE'));
+if ~isempty(subIdx)
+    fprintf('\n=== SUBSTANTIVE drifts (mean abs delta >= %.2f) ===\n', opts.TinyThreshold);
+    [~, sortIdx] = sort([rows(subIdx).mad], 'descend');
+    for k = sortIdx
+        r = rows(subIdx(k));
+        fprintf('  %-50s mad=%6.2f  now=%d  other=%d\n', ...
+            r.name, r.mad, r.now_bytes, r.other_bytes);
+    end
+end
+
+% ONLY_OTHER: regressions
+onlyOldIdx = find(strcmp(kinds, 'ONLY_OTHER'));
+if ~isempty(onlyOldIdx)
+    fprintf('\n=== ONLY_OTHER (figure present in baseline but not now) ===\n');
+    for k = onlyOldIdx'
+        fprintf('  %s (was %d B)\n', rows(k).name, rows(k).other_bytes);
+    end
+end
+
+% Per-helpfile rollup
+helpfiles = unique({rows.helpfile});
+fprintf('\n=== Per-helpfile rollup (showing rows with non-zero SUBST / NEW / LOST) ===\n');
+fprintf('  %-40s %-6s %-6s %-6s %-6s %-6s\n', 'helpfile', 'IDENT', 'TINY', 'SUBST', 'NEW', 'LOST');
+for h = 1:numel(helpfiles)
+    hf = helpfiles{h};
+    hRows = rows(strcmp({rows.helpfile}, hf));
+    c = countKinds(hRows);
+    if c.sub > 0 || c.lost > 0 || c.new > 0
+        fprintf('  %-40s %-6d %-6d %-6d %-6d %-6d\n', hf, c.ident, c.tiny, c.sub, c.new, c.lost);
+    end
+end
+
+report = rows;
+end
+
+function c = countKinds(hRows)
+kinds = {hRows.kind};
+c.ident = sum(strcmp(kinds, 'IDENTICAL'));
+c.tiny  = sum(strcmp(kinds, 'TINY'));
+c.sub   = sum(strcmp(kinds, 'SUBSTANTIVE'));
+c.new   = sum(strcmp(kinds, 'ONLY_NOW'));
+c.lost  = sum(strcmp(kinds, 'ONLY_OTHER'));
+end
+
+function m = listPngsAsMap(d)
+m = containers.Map('KeyType','char','ValueType','any');
+if ~isfolder(d); return; end
+pngs = dir(fullfile(d, '*.png'));
+for k = 1:numel(pngs)
+    m(pngs(k).name) = pngs(k);
+end
+end
+
+function dst = stageHeadHelpfiles(repoRoot)
+dst = tempname;
+mkdir(dst);
+[stat, list] = system(sprintf('cd %s && git ls-tree -r --name-only HEAD helpfiles/ | grep -E "\\.png$"', repoRoot));
+if stat ~= 0
+    error('check_helpfile_drift:GitListFailed', 'git ls-tree failed for %s', repoRoot);
+end
+files = strsplit(strtrim(list), newline);
+for k = 1:numel(files)
+    if isempty(files{k}); continue; end
+    [~, name, ext] = fileparts(files{k});
+    src = fullfile(repoRoot, files{k});
+    if isfile(src)
+        copyfile(src, fullfile(dst, [name ext]));
+    end
+end
+end
+
+function tryRmdir(d)
+if isfolder(d)
+    try; rmdir(d, 's'); catch; end
+end
+end

--- a/tools/smoke_helpfile.m
+++ b/tools/smoke_helpfile.m
@@ -1,0 +1,129 @@
+function smoke_helpfile(helpfileName, varargin)
+%SMOKE_HELPFILE Publish one helpfile in an isolated sandbox and report.
+%
+% Usage:
+%   tools.smoke_helpfile('DecodingExample')
+%   tools.smoke_helpfile('HybridFilterExample', 'CompareToHead', false)
+%
+% Stages the named helpfile's .m (plus its siblings, minus any .mlx that
+% would shadow it) into a temp directory, runs `publish` with EvalCode=true,
+% and reports:
+%   - publish OK / FAIL with stack on error
+%   - count of figure PNGs produced (numeric-suffix Foo_NN.png only;
+%     LaTeX-equation snapshots Foo_eq<hex>.png excluded)
+%   - per-PNG size with SUSPECT-BLANK flag for any < BlankThreshold bytes
+%   - delta vs HEAD-committed figure count (optional, default on)
+%
+% Designed to surface the same class of regressions that
+% publish_all_helpfiles' built-in validateNoBlankFigures catches, but for
+% one helpfile at a time so you can iterate quickly on a single .m without
+% paying the ~19-minute cost of the full predeploy publish gate.
+%
+% See also: publish_all_helpfiles, tools.check_helpfile_drift
+%
+% Introduced after the PR #105 / #106 / #109 chain made clear that
+% one-at-a-time publish smoke testing is essential before any helpfile
+% edit ships.
+
+p = inputParser;
+p.FunctionName = 'tools.smoke_helpfile';
+addRequired(p, 'helpfileName', @(x) ischar(x) || (isstring(x) && isscalar(x)));
+addParameter(p, 'CompareToHead', true, @(x) islogical(x) || (isnumeric(x) && isscalar(x)));
+addParameter(p, 'BlankThreshold', 5000, @(x) isnumeric(x) && isscalar(x) && x >= 0);
+parse(p, helpfileName, varargin{:});
+opts = p.Results;
+helpfileName = char(string(opts.helpfileName));
+
+repoRoot = fileparts(fileparts(mfilename('fullpath')));
+helpDir = fullfile(repoRoot, 'helpfiles');
+mPath   = fullfile(helpDir, [helpfileName '.m']);
+if ~isfile(mPath)
+    fprintf('ERROR: helpfile .m not found: %s\n', mPath);
+    return
+end
+
+stagingDir = tempname; mkdir(stagingDir);
+outputDir  = tempname; mkdir(outputDir);
+cleanup = onCleanup(@() tryRmdirs(stagingDir, outputDir)); %#ok<NASGU>
+
+copyfile(fullfile(helpDir, '*'), stagingDir);
+mlxFiles = dir(fullfile(stagingDir, '*.mlx'));
+for i=1:numel(mlxFiles)
+    delete(fullfile(mlxFiles(i).folder, mlxFiles(i).name));
+end
+
+startDir = pwd;
+restoreDir = onCleanup(@() cd(startDir)); %#ok<NASGU>
+addpath(stagingDir, '-begin');
+cd(stagingDir);
+
+priorVisibility = get(groot, 'defaultFigureVisible');
+set(groot, 'defaultFigureVisible', 'on');
+restoreVisibility = onCleanup(@() set(groot, 'defaultFigureVisible', priorVisibility)); %#ok<NASGU>
+
+rng(0, 'twister');
+pubOpts = struct('outputDir', outputDir, 'format', 'html', 'evalCode', true);
+fprintf('\n=== smoke: %s ===\n', helpfileName);
+tStart = tic;
+publishOK = false;
+try
+    publish(helpfileName, pubOpts);
+    publishOK = true;
+    fprintf('  publish OK (%.1fs)\n', toc(tStart));
+catch ME
+    fprintf('  publish FAIL (%.1fs): %s\n', toc(tStart), ME.message);
+    for i=1:min(4, numel(ME.stack))
+        fprintf('    [%d] %s line %d\n', i, ME.stack(i).name, ME.stack(i).line);
+    end
+end
+if ~publishOK; return; end
+
+pngs = dir(fullfile(outputDir, [helpfileName '_*.png']));
+realCount = 0;
+eqCount = 0;
+rows = {};
+for k = 1:numel(pngs)
+    nm = pngs(k).name;
+    [~, base] = fileparts(nm);
+    if ~isempty(regexp(base, '_\d+$', 'once'))
+        realCount = realCount + 1;
+        flag = '';
+        if pngs(k).bytes < opts.BlankThreshold
+            flag = sprintf(' SUSPECT-BLANK (< %d B)', opts.BlankThreshold);
+        end
+        rows{end+1} = sprintf('  %s: %d B%s', nm, pngs(k).bytes, flag); %#ok<AGROW>
+    elseif contains(base, '_eq')
+        eqCount = eqCount + 1;
+    end
+end
+fprintf('  produced %d figure PNGs (+ %d equation PNGs)\n', realCount, eqCount);
+for k = 1:numel(rows)
+    fprintf('%s\n', rows{k});
+end
+
+if opts.CompareToHead
+    [stat, gitList] = system(sprintf( ...
+        'cd %s && git ls-tree -r --name-only HEAD helpfiles/ | grep -E "^helpfiles/%s_[0-9]{2}\\.png$" | sort', ...
+        startDir, helpfileName));
+    if stat == 0
+        headFiles = strsplit(strtrim(gitList), newline);
+        if ~isempty(headFiles{1})
+            fprintf('  HEAD baseline: %d  |  Now: %d  |  delta: %+d\n', ...
+                numel(headFiles), realCount, realCount - numel(headFiles));
+        end
+    end
+end
+end
+
+function tryRmdirs(varargin)
+for i = 1:nargin
+    d = varargin{i};
+    if isfolder(d)
+        try
+            rmdir(d, 's');
+        catch
+            % best-effort cleanup
+        end
+    end
+end
+end


### PR DESCRIPTION
Both harnesses were authored ad-hoc in `/tmp/` during the PR #105–#109 chain. They turned out to be load-bearing diagnostics — promoting them so the next contributor doesn't re-derive them.

## New tools

| File | Purpose |
|---|---|
| `tools/smoke_helpfile.m` | Publish one helpfile in a staged sandbox. Strips `.mlx` siblings (CONTRIBUTING.md shadow trap), forces `defaultFigureVisible='on'` (PR #107 silent-suppression fix), reports per-PNG size + blank suspects + delta vs HEAD baseline. |
| `tools/check_helpfile_drift.m` | Pixel-diff two helpfile directories. Default compares current `helpfiles/` against HEAD-staged temp; pass `'Other'` to compare against an older worktree. Same verdict classes as `check_readme_figures.m` (IDENTICAL / TINY / SUBSTANTIVE / DIM_DIFF / ONLY_NOW / ONLY_OTHER). |

## CONTRIBUTING.md
- Recommends `tools/smoke_helpfile.m` as the smoke-test entry point. Older `which()` / `movefile` patterns kept as fallbacks for ad-hoc work.
- New paragraph in the "verifying regenerated artifacts" subsection points at `check_helpfile_drift` with the `'Other'` invocation for drift-vs-historical-publish use cases.

## Test gates
| Gate | Result |
|---|---|
| `tools/run_unit_tests.sh` | **79 / 79 pass** |
| `smoke_helpfile('HybridFilterExample')` | OK (2 figs, sizes match HEAD) |
| `check_helpfile_drift` (no-op self-comparison) | 166 IDENTICAL, 0 SUBSTANTIVE |