### PR TITLE
fix(decoding): two PointProcessEM defects surfaced by checkcode

### DIFF
--- a/+nstat/+decoding/PointProcessEM.m
+++ b/+nstat/+decoding/PointProcessEM.m
@@ -265,7 +265,13 @@ classdef PointProcessEM
  ExplambdaDeltaXkXk=1/McExp*(repmat(ld,[size(xk,1),1]).*xk)*xk';
  ExplambdaDeltaSqXkXkT=1/McExp*(repmat(ld.^2,[size(xk,1),1]).*xk)*xk';
  ExplambdaDeltaCubeXkXkT=1/McExp*(repmat(ld.^3,[size(xk,1),1]).*xk)*xk';
- HessianTerm(:,:,k)+ExplambdaDeltaXkXk+ExplambdaDeltaSqXkXkT-2*ExplambdaDeltaCubeXkXkT;
+ % FIX: missing `=`. The previous code computed a value and silently
+ % discarded it, leaving HessianTerm(:,:,k) at its initial 0. The
+ % binomial-branch parameter standard errors (IBetaComp) were
+ % effectively all-zero. Parallel structure to the poisson branch a
+ % few lines above which does `HessianTerm(:,:,k) = -1/McExp*(...)`.
+ % Surfaced by checkcode VUNUS finding 2026-06-22.
+ HessianTerm(:,:,k) = ExplambdaDeltaXkXk + ExplambdaDeltaSqXkXkT - 2*ExplambdaDeltaCubeXkXkT;
  
  end
  startInd = size(betahat,1)*(c-1)+1; endInd = size(betahat,1)*c;
@@ -1108,7 +1114,17 @@ classdef PointProcessEM
  
  spikeColl = nstColl(nstNew); % Create a neural spike train collection
  else
- time;
+ % FIX: the with-history branch of Ikeda acceleration was never
+ % implemented. The previous code had a bare `time;` here which
+ % evaluated `time` and silently discarded the result, leaving
+ % `spikeColl` either undefined (error on line below) or stale
+ % from outside this block. Better to fail loud than silently
+ % decode against the wrong data. Surfaced by checkcode VUNUS
+ % finding 2026-06-22.
+ error('nstat:decoding:PointProcessEM:IkedaHistNotImplemented', ...
+     ['Ikeda acceleration with non-zero history coefficients is ' ...
+      'not implemented (gammahat ~= 0 branch). Either disable ' ...
+      'IkedaAcc or restructure to handle history.']);
  end
  
  dNNew=spikeColl.dataToMatrix';


### PR DESCRIPTION
Step 3 of the 5-step plan ran \`checkcode\` on \`+nstat/+decoding/*.m\`. Of 597 total findings, 593 are style/performance (AGROW, NASGU, ISCL, etc.). 4 priority findings; **2 are real bugs**:

## 1. \`PointProcessEM.m:268\` — missing \`=\` in binomial Hessian

\`\`\`matlab
% Before:
HessianTerm(:,:,k)+ExplambdaDeltaXkXk+ExplambdaDeltaSqXkXkT-2*ExplambdaDeltaCubeXkXkT;

% After:
HessianTerm(:,:,k) = ExplambdaDeltaXkXk + ExplambdaDeltaSqXkXkT - 2*ExplambdaDeltaCubeXkXkT;
\`\`\`

The computed value was silently discarded — \`HessianTerm(:,:,k)\` stayed at its initialized 0, so \`IBetaComp\` for binomial parameter standard errors was effectively all-zero. The poisson branch (line 244) uses the correct form. **Effect**: SE/CI estimates for binomial \`PointProcessEM\` fits were wrong. Filter convergence and KS values are unaffected (they don't depend on this Hessian).

## 2. \`PointProcessEM.m:1111\` — bare \`time;\` in dead branch

\`\`\`matlab
% Before:
else
    time;
end

% After:
else
    error('nstat:decoding:PointProcessEM:IkedaHistNotImplemented', ...);
end
\`\`\`

The with-history branch of Ikeda acceleration (\`gammahat ~= 0\`) was never implemented — it evaluated \`time\` and discarded the result, leaving \`spikeColl\` either undefined or stale from outside the block. Replaced with a loud failure so callers know this path isn't supported instead of silently decoding against wrong data.

## Test gates
| Gate | Result |
|---|---|
| \`tools/run_unit_tests.sh\` | **79 / 79 pass** |
| \`TestParityAgainstBaseline\` (legacy + modern) | numeric + plots **PASS** |

The binomial-SE code path is not exercised by the baseline corpus; no shift expected and none observed.

## Out of scope here
Other 593 \`checkcode\` findings are style/performance:
\`AGROW=275, NASGU=124, ISCL=73, ASGLU=47, NCOMMA=40, PREALL=14, ...\`. Worth a separate refactor sweep when there's time.