### PR TITLE
release(v1.5.1): bump ToolboxVersion in toolboxOptions.m to 1.5.1

### DIFF
--- a/toolboxOptions.m
+++ b/toolboxOptions.m
@@ -23,7 +23,7 @@ opts = matlab.addons.toolbox.ToolboxOptions(repoRoot, identifier);
 
 % --- Metadata ----------------------------------------------------------
 opts.ToolboxName     = "nSTAT";
-opts.ToolboxVersion  = "1.5.0";
+opts.ToolboxVersion  = "1.5.1";
 opts.Description     = "Neural Spike Train Analysis Toolbox for MATLAB. Point-process and state-space methods for spike-train analysis: PP-GLM fitting (Poisson and binomial), time-rescaling KS goodness-of-fit, PPAF (point-process adaptive filter), PPHF (hybrid discrete + continuous-state filter), SSGLM (state-space GLM), and PPLFP (multi-modal spike + LFP sensor-fusion filter).";
 opts.Summary         = "Point-process and state-space methods for spike-train analysis (Cajigas, Malik & Brown 2012).";
 


### PR DESCRIPTION
Companion to PR #113. `toolboxOptions.m` was still pinned at `1.5.0`, so `packageToolbox` produced `nSTAT-1.5.0.mltbx` instead of `nSTAT-1.5.1.mltbx`. One-line fix. Re-running `packageToolbox` now produces the correctly-versioned 13 MB `.mltbx` that will be attached to the GitHub Release at the v1.5.1 tag.