### PR TITLE
docs(helpfiles): collapse DocumentationSetup2025b to evergreen DocumentationSetup

### DIFF
--- a/helpfiles/DocumentationSetup.html
+++ b/helpfiles/DocumentationSetup.html
@@ -6,11 +6,11 @@
 This HTML was auto-generated from MATLAB code.
 To make changes, update the MATLAB code and republish this document.
       -->
-<title>MATLAB 2025b Help Integration for nSTAT</title>
+<title>MATLAB Help Integration for nSTAT</title>
 <meta name="generator" content="MATLAB 26.1">
 <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/">
 <meta name="DC.date" content="2026-06-22">
-<meta name="DC.source" content="DocumentationSetup2025b.m">
+<meta name="DC.source" content="DocumentationSetup.m">
 <style type="text/css">
 html,body,div,span,applet,object,iframe,h1,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,code,del,dfn,em,font,img,ins,kbd,q,s,samp,small,strike,strong,tt,var,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,label,legend,table,caption,tbody,tfoot,thead,tr,th,td{margin:0;padding:0;border:0;outline:0;font-size:100%;vertical-align:baseline;background:transparent}body{line-height:1}ol,ul{list-style:none}blockquote,q{quotes:none}blockquote:before,blockquote:after,q:before,q:after{content:'';content:none}:focus{outine:0}ins{text-decoration:none}del{text-decoration:line-through}table{border-collapse:collapse;border-spacing:0}
 
@@ -76,10 +76,9 @@ table td { padding:7px 5px; text-align:left; vertical-align:top; border:1px soli
 </head>
 <body>
 <div class="content">
-<h1>MATLAB 2025b Help Integration for nSTAT</h1>
+<h1>MATLAB Help Integration for nSTAT</h1>
 <!--introduction-->
 <p>This page documents the help-file structure used by nSTAT so it appears as supplemental software documentation in MATLAB.</p>
-<p>The configuration in this release is aligned with MATLAB R2025b.</p>
 <!--/introduction-->
 <h2>Contents</h2>
 <div>
@@ -91,7 +90,7 @@ table td { padding:7px 5px; text-align:left; vertical-align:top; border:1px soli
 <a href="#2">Build and Refresh the Search Database</a>
 </li>
 <li>
-<a href="#3">MATLAB 2025b Behavior</a>
+<a href="#3">Where the docs appear in MATLAB</a>
 </li>
 <li>
 <a href="#4">Troubleshooting</a>
@@ -117,8 +116,8 @@ helpDir = fullfile(rootDir,<span class="string">'helpfiles'</span>);
 builddocsearchdb(helpDir);
 rehash <span class="string">toolboxcache</span>;
 </pre>
-<h2 id="3">MATLAB 2025b Behavior</h2>
-<p>Starting in R2024b, toolbox documentation is shown in the system browser. External toolbox documentation appears in MATLAB documentation under Supplemental Software.</p>
+<h2 id="3">Where the docs appear in MATLAB</h2>
+<p>Since R2024b, toolbox documentation is shown in the system browser. External toolbox documentation appears in MATLAB documentation under Supplemental Software.</p>
 <p>Use these pages as entry points:</p>
 <div>
 <ul>
@@ -149,11 +148,9 @@ rehash <span class="string">toolboxcache</span>;
 </div>
 <!--
 ##### SOURCE BEGIN #####
-%% MATLAB 2025b Help Integration for nSTAT
+%% MATLAB Help Integration for nSTAT
 % This page documents the help-file structure used by nSTAT so it appears as
 % supplemental software documentation in MATLAB.
-%
-% The configuration in this release is aligned with MATLAB R2025b.
 %
 %% Required Files
 % nSTAT uses the standard external toolbox documentation layout:
@@ -174,8 +171,8 @@ rehash <span class="string">toolboxcache</span>;
 %   builddocsearchdb(helpDir);
 %   rehash toolboxcache;
 %
-%% MATLAB 2025b Behavior
-% Starting in R2024b, toolbox documentation is shown in the system browser.
+%% Where the docs appear in MATLAB
+% Since R2024b, toolbox documentation is shown in the system browser.
 % External toolbox documentation appears in MATLAB documentation under
 % Supplemental Software.
 %

--- a/helpfiles/DocumentationSetup.m
+++ b/helpfiles/DocumentationSetup.m
@@ -1,8 +1,6 @@
-%% MATLAB 2025b Help Integration for nSTAT
+%% MATLAB Help Integration for nSTAT
 % This page documents the help-file structure used by nSTAT so it appears as
 % supplemental software documentation in MATLAB.
-%
-% The configuration in this release is aligned with MATLAB R2025b.
 %
 %% Required Files
 % nSTAT uses the standard external toolbox documentation layout:
@@ -23,8 +21,8 @@
 %   builddocsearchdb(helpDir);
 %   rehash toolboxcache;
 %
-%% MATLAB 2025b Behavior
-% Starting in R2024b, toolbox documentation is shown in the system browser.
+%% Where the docs appear in MATLAB
+% Since R2024b, toolbox documentation is shown in the system browser.
 % External toolbox documentation appears in MATLAB documentation under
 % Supplemental Software.
 %

--- a/helpfiles/NeuralSpikeAnalysis_top.html
+++ b/helpfiles/NeuralSpikeAnalysis_top.html
@@ -107,7 +107,7 @@ table td { padding:7px 5px; text-align:left; vertical-align:top; border:1px soli
 <a href="nSTATPaperExamples.html">nSTAT Paper Examples</a>
 </li>
 <li>
-<a href="DocumentationSetup2025b.html">MATLAB 2025b Help Integration Guide</a>
+<a href="DocumentationSetup.html">MATLAB Help Integration Guide</a>
 </li>
 </ul>
 </div>
@@ -149,7 +149,7 @@ table td { padding:7px 5px; text-align:left; vertical-align:top; border:1px soli
 % * <ClassDefinitions.html Class Definitions>
 % * <Examples.html Example Index>
 % * <nSTATPaperExamples.html nSTAT Paper Examples>
-% * <DocumentationSetup2025b.html MATLAB 2025b Help Integration Guide>
+% * <DocumentationSetup.html MATLAB Help Integration Guide>
 %
 % *Citation*
 %

--- a/helpfiles/NeuralSpikeAnalysis_top.m
+++ b/helpfiles/NeuralSpikeAnalysis_top.m
@@ -24,7 +24,7 @@
 % * <ClassDefinitions.html Class Definitions>
 % * <Examples.html Example Index>
 % * <nSTATPaperExamples.html nSTAT Paper Examples>
-% * <DocumentationSetup2025b.html MATLAB 2025b Help Integration Guide>
+% * <DocumentationSetup.html MATLAB Help Integration Guide>
 %
 % *Citation*
 %

--- a/helpfiles/helptoc.xml
+++ b/helpfiles/helptoc.xml
@@ -3,7 +3,7 @@
   <tocitem target="NeuralSpikeAnalysis_top.html" image="HelpIcon.ROOT" id="nstat_home">nSTAT Neural Spike Train Analysis Toolbox
     <tocitem target="NeuralSpikeAnalysis_top.html" image="HelpIcon.FUNCTION" id="nstat_overview">Overview</tocitem>
     <tocitem target="PaperOverview.html" image="HelpIcon.FUNCTION" id="nstat_paper_overview">Paper-Aligned Toolbox Map</tocitem>
-    <tocitem target="DocumentationSetup2025b.html" image="HelpIcon.FUNCTION" id="nstat_2025b_setup">MATLAB 2025b Help Integration</tocitem>
+    <tocitem target="DocumentationSetup.html" image="HelpIcon.FUNCTION" id="nstat_help_integration">MATLAB Help Integration</tocitem>
 
     <tocitem target="ClassDefinitions.html" image="HelpIcon.FUNCTION" id="nstat_class_definitions">Class Definitions</tocitem>
     <tocitem target="SignalObj.html" image="HelpIcon.FUNCTION" id="nstat_signalobj_reference">SignalObj Reference</tocitem>


### PR DESCRIPTION
The only genuinely version-specific line in the page was "The configuration in this release is aligned with MATLAB R2025b." Everything else (`info.xml`, `helptoc.xml`, `builddocsearchdb`, supplemental-software placement, system-browser display) has been stable across the R2024b → R2026a window. Removing the version suffix and the single version-specific line eliminates the per-release rename treadmill.

## Renames

| From | To |
|---|---|
| `helpfiles/DocumentationSetup2025b.m` | `helpfiles/DocumentationSetup.m` |
| `helpfiles/DocumentationSetup2025b.html` | `helpfiles/DocumentationSetup.html` |

## Content edits

Mirrored in both the `.m` source and the published `.html` (including the `SOURCE BEGIN/END` comment block at the bottom of the HTML so the file stays internally consistent until the next predeploy regen):

- Title: "MATLAB 2025b Help Integration for nSTAT" → "MATLAB Help Integration for nSTAT"
- Drop the "aligned with MATLAB R2025b" sentence
- Section heading: "MATLAB 2025b Behavior" → "Where the docs appear in MATLAB"
- "Starting in R2024b, …" → "Since R2024b, …" — same historical fact, framed as evergreen reference
- `<meta name="DC.source">` → `DocumentationSetup.m`

## Reference updates

| File | Change |
|---|---|
| `helpfiles/helptoc.xml` | target/id/label all de-versioned: `target="DocumentationSetup.html"`, `id="nstat_help_integration"`, label "MATLAB Help Integration" |
| `helpfiles/NeuralSpikeAnalysis_top.m` | link target + label |
| `helpfiles/NeuralSpikeAnalysis_top.html` | link target + label, in both the rendered `<a>` and the embedded source-listing comment |

## Verification

| Check | Result |
|---|---|
| `python3 tools/lint_helptoc.py` | **40 / 40 file-path targets resolve**, 2 external URLs ignored, 0 broken |
| `grep -rn 'DocumentationSetup2025b\|2025b Help Integration\|nstat_2025b_setup'` across tracked code | **zero matches** |
| `validateHelpTargets` (the predeploy validator that requires every `helptoc.xml` target to be a real file) | passes (`DocumentationSetup.html` exists) |

## What happens at next predeploy

The next predeploy run on R2026a regenerates `DocumentationSetup.html` cleanly via `publish_all_helpfiles` — the hand-edited HTML in this commit keeps the link integrity intact in the meantime. `builddocsearchdb` picks up the new filename.