### PR TITLE
docs(contributing): document the two orphan-figure antipattern shapes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,16 @@ The convention (PR #116):
 
 The PR-#116 close-all sweep across 7 helpfiles eliminated 13 duplicate-figure captures and was the dominant cause of the historical 18.8-min publish time. If you add a new helpfile, follow the same pattern; if you edit one and notice the publish report's `snapshots/figure` ratio climbing well above 1.0 for that file, an open figure has leaked across sections.
 
+#### Two orphan-figure antipattern shapes to watch for at PR review
+
+Both root-cause to the same `publish()` semantic, but they need **opposite** fixes — be deliberate about which one you're looking at.
+
+**Shape A — figure leaks into text-only sections** (PR #116, PR #123). A `figure(...)` is created in section X; sections Y, Z, … after it are pure text/markup with no plotting code; the figure isn't closed until late. `publish()` re-snapshots the same handle at the end of each text-only section. Each orphan looks **identical to its neighbor** in the HTML — that's the giveaway. *Fix:* `close all;` at the start of each affected titled `%%` section (the convention above).
+
+**Shape B — composite figure built across sections** (PR #121). A `figure(...)` is created in section X; sections Y, Z extend the **same handle** with more `subplot(...)` calls (typically `subplot(N,M,[a b c])` spanning indices). `publish()` snapshots the figure at the end of section X (incomplete), then again at end of section Y (more complete), then at end of section Z (fully built). Each orphan is a **partial-build** of the final composite — the final image is what was intended. *Fix:* the **opposite** of Shape A — collapse the building sections into one `%%` section so the figure is snapshotted once, fully built. Demote the inner `%% Heading` lines to `% Heading` comments. Adding `close all;` here would **destroy the intended composite**.
+
+Quick check: read the section headings between `figure(` and the next `close all;`. If those sections produce **no new plotting code**, you have Shape A → apply close-all. If they have spanning-index `subplot(...)` calls that extend the same figure handle, you have Shape B → consolidate.
+
 ### Verifying regenerated `.mlx` / `.html` / PNG artifacts before commit
 
 Regenerating the rendered helpfile docs (`.mlx`, `.html`, per-figure PNGs) is *not* a mechanical follow-up — the rendered artifacts can silently degrade vs the committed baseline, and the committed copies under `helpfiles/` are what GitHub serves to users. PR #88/#89/#103 → PR #105 (rollback) is a case where the regeneration looked successful at the function level but produced a measurably worse `.html` than the pre-edit baseline.


### PR DESCRIPTION
Today's audit work surfaced that the orphan-figure antipattern in helpfile `.m` files comes in **two distinct shapes, with opposite fixes**. A reviewer who knows the Phase B `close all;` convention but not the shape-B "consolidate sections" rule could miss the second shape at PR review. This adds a brief subsection that catalogues both so future contributors recognize them.

## What's added

A new `#### Two orphan-figure antipattern shapes to watch for at PR review` subsection inside the existing `### Helpfile authoring: `close all;` between `%%` sections` section.

| Shape | Pattern | Symptom | Fix | Examples |
|---|---|---|---|---|
| **A** | `figure(...)` in section X; sections Y, Z after it are text-only; figure not closed until late | `publish()` re-snapshots the same handle at end of each text-only section. **Each orphan looks identical to its neighbor.** | `close all;` at the start of each affected titled section (the existing convention) | PR #116, PR #123 |
| **B** | `figure(...)` in section X; sections Y, Z extend the same handle via `subplot(N,M,[a b c])` spanning-index calls | `publish()` snapshots in progressively-more-complete states. **Each orphan is a partial build of the final composite.** | **Opposite of A** — collapse the building sections into one `%%` section. `close all;` would destroy the intended composite. | PR #121 |

Quick reviewer check (last paragraph of the addition): read the section headings between `figure(` and the next `close all;`. If those sections produce no new plotting code → Shape A → apply close-all. If they have spanning-index `subplot(...)` calls extending the same handle → Shape B → consolidate.

## Why this is a separate PR from v1.5.2

This is docs hygiene capturing today's learnings for the next contributor, not a code change. Intentionally deferred so the v1.5.2 release tag is clean code/perf/fix-only. Will roll into v1.5.3.

## Files

`CONTRIBUTING.md` — +10 lines (one new subsection inside an existing section).