### PR TITLE
fix(publish): close stale figures at start of each parfor iteration to eliminate worker-state figure leak

### DIFF
--- a/helpfiles/publish_all_helpfiles.m
+++ b/helpfiles/publish_all_helpfiles.m
@@ -230,6 +230,19 @@ addpath(stagingDir, '-begin');
 cd(stagingDir);
 set(groot, 'defaultFigureVisible', 'on');
 
+% Close any figures left open by a prior parfor iteration on this
+% worker. publish() does not close figures it opened, and the
+% section-end snapshot in the NEXT iteration captures every open
+% figure -- so stale figures from the previous helpfile get re-
+% snapshotted into this helpfile's outputs, named with this helpfile's
+% baseName and re-numbered into its sequence. That's the mechanism
+% behind the 18-21 figure variance observed for SignalObjExamples
+% across runs of publish_all_helpfiles (smoke_helpfile, which is
+% sequential and starts in a clean MATLAB instance, produces 17
+% deterministically). Clearing here makes every parfor iteration
+% start from a clean visual state.
+close all force;
+
 [~, baseName] = fileparts(stageFile.name);
 tStart = tic;
 timing = struct('name', stageFile.name, 'wallSec', 0, 'figCount', 0, ...


### PR DESCRIPTION
Root cause of the SignalObjExamples "18-21 figs across runs" variance (deferred from PR #126 and v1.5.2 release notes).

## Diagnosis

`smoke_helpfile('SignalObjExamples')` ran 3 times consecutively in a fresh MATLAB instance produces **17 / 17 / 17 figs** — deterministic.

`publish_all_helpfiles` parallel mode produces 18-21 across runs:
- 20 (HEAD post-PR #116)
- 21 (v1.5.2 predeploy)
- 18 (PR #126 republish)

Smoke is single-call, single-process, no parfor pool. Variance only appears in the parfor path → isolation must be inside the worker between iterations.

## Root cause

`publish()` does **NOT close figures it opened** during a script run. In parfor mode, parpool workers are persistent MATLAB processes that handle multiple iterations sequentially. Stale figures from the previous helpfile's `publish()` call remain open when the worker moves to its next iteration. The new iteration's `publish()` snapshots every open figure at every section boundary — so stale figures get re-snapshotted into THIS helpfile's outputs, named with this helpfile's `baseName` and numbered into its sequence. The result was a 1-4 figure inflation per helpfile depending on which prior file the worker had just processed.

## Fix

Add `close all force` at the top of `publishOneStaged`, right after the worker's idempotent setup (`addpath` / `cd` / `groot`). `force` covers figures with a `CloseRequestFcn` that would otherwise prevent closing.

This makes every parfor iteration start from a guaranteed clean figure state. The first iteration on a worker is a no-op (nothing was open); subsequent iterations get the cleanup that `publish()` neglects.

`publishOneReference` is **not** modified — it runs serially in the main MATLAB process with `evalCode: false` (no script execution, no figure captures), so it doesn't need the same fix.

## Effect on figure counts

Post-fix parallel publish:

| Helpfile | Before | After | Notes |
|---|---:|---:|---|
| AnalysisExamples2 | 5 | **4** | One more latent orphan eliminated |
| HybridFilterExample | 3 | 3 | No change |
| PPSimExample | 4 | 4 | No change |
| **SignalObjExamples** | **18-21 (variance)** | **19 (stable)** | Variance eliminated; residual 17-vs-19 vs smoke is a different mechanism (probably per-worker init state), kept on deferred ledger |
| nSTATPaperExamples | 25 | 26 (+1) | Independent publish() non-determinism unrelated to this fix; under separate investigation if it recurs |

## Cache impact

This edit invalidates Phase D's `globalHash` (publish_all_helpfiles.m content is in the hash). The next publish run will be a cache MISS rebuild. After that, the cache stabilizes against the new orchestrator hash.

## Scope

Orchestrator-only change. Helpfile artifacts (HTMLs + PNGs) **not** committed; they rebaseline naturally at the next predeploy gate.

## Files

`helpfiles/publish_all_helpfiles.m` — +13 lines (one `close all force` + an explanatory comment block above it documenting the parfor-worker-state mechanism).