### PR TITLE
fix(SSGLM): regularize PPSS_EStep covariance + mask empty-bin sentinels in Q init (nstat-python#249 parity)

### DIFF
--- a/+nstat/+decoding/SSGLM.m
+++ b/+nstat/+decoding/SSGLM.m
@@ -365,17 +365,27 @@ classdef SSGLM
 
 % invW_u = pinv(W_p(:,:,k))+ sumValMat;
 % W_u(:,:,k) = pinv(invW_u);% +100*diag(eps*rand(size(W_p,1),1));
-% 
- 
-
+%
+ % FIX (nstat-python#249): regularize the posterior covariance update.
+ % For high-rate or sparse bins, lambdaDelta = exp(stimK).*histEffect can
+ % reach e^30 ~ 1e13, making sumValMat (and hence invW_u) non-finite.
+ % The bare inv + eig flow then either errors with "Eigenvalues did not
+ % converge" or returns garbage. The Python port (PPSS_EStep) aborted EM
+ % entirely on this. nstat.decoding.SSGLM.robustPsdInverse mirrors the
+ % regularized update -- nan-scrub, symmetrize, ridge, inv with pinv
+ % fallback, eigenvalue floor at eps -- and returns the same PSD matrix
+ % the previous code did on well-conditioned input.
  invW_u = eye(size(W_p(:,:,k)))/W_p(:,:,k)+ sumValMat;
- W_u(:,:,k) = eye(size(invW_u))/invW_u;% +100*diag(eps*rand(size(W_p,1),1));
+ W_u(:,:,k) = nstat.decoding.SSGLM.robustPsdInverse(invW_u, size(W_p,1));
 
- % Maintain Positive Definiteness
- % Make sure eigenvalues are positive
- [vec,val]=eig(W_u(:,:,k) ); val(val<=0)=eps;
- W_u(:,:,k) =vec*val*vec';
- x_u(:,k) = x_p(:,k) + W_u(:,:,k)*(sumValVec);
+ % FIX (nstat-python#249): bound the log-rate state so a diverged step
+ % cannot poison the next iteration via x_p = A*x_u. Real states sit
+ % near log(rate*delta) ~ [-12, 5]; |x| <= 50 corresponds to rate in
+ % (e^-50, e^50)/delta -- far outside any physical neural firing rate.
+ SSGLM_STATE_BOUND = 50;
+ x_u(:,k) = max(-SSGLM_STATE_BOUND, ...
+                min(SSGLM_STATE_BOUND, ...
+                    x_p(:,k) + W_u(:,:,k)*(sumValVec)));
 
  end
 
@@ -571,6 +581,45 @@ classdef SSGLM
  end
 
  % pause;
+ end
+
+ function W = robustPsdInverse(invW, dim, ridge)
+ %ROBUSTPSDINVERSE invert a precision matrix and project to PSD, robust to
+ % non-finite entries from extreme observed-information conditioning.
+ %
+ % Mirrors the original `inv` + eigenvalue-floor flow used in PPSS_EStep,
+ % but is nan-safe and never aborts: scrub non-finite entries, symmetrize,
+ % add a tiny ridge, attempt `inv` and fall back to `pinv` if the result
+ % is non-finite, scrub again, run `eig`, floor non-positive eigenvalues
+ % to eps. On well-conditioned input it returns the same PSD matrix the
+ % previous code did (no behavioural change). On the extreme-conditioning
+ % path that previously crashed the EM, it returns a near-zero PSD matrix
+ % so the Kalman update degrades gracefully instead of poisoning the next
+ % iteration with NaN/Inf entries.
+ %
+ % Mirrors nstat-python's _robust_psd_inverse (cajigaslab/nSTAT-python#249).
+ if nargin < 3, ridge = 1e-12; end
+ invW(~isfinite(invW)) = 0;
+ invW = 0.5*(invW + invW.') + ridge*eye(dim);
+ warnState = warning('off','MATLAB:singularMatrix');
+ cleanupSing = onCleanup(@() warning(warnState)); %#ok<NASGU>
+ warnState2 = warning('off','MATLAB:nearlySingularMatrix');
+ cleanupNear = onCleanup(@() warning(warnState2)); %#ok<NASGU>
+ W = inv(invW);
+ if any(~isfinite(W(:)))
+ W = pinv(invW);
+ end
+ W = 0.5*(W + W.');
+ W(~isfinite(W)) = 0;
+ try
+ [vec, val] = eig(W);
+ catch
+ W = eye(dim) * max(ridge, eps);
+ return
+ end
+ val(val <= 0) = eps;
+ W = vec*val*vec.';
+ W = 0.5*(W + W.');  % final symmetrize against round-off
  end
  end
 end

--- a/nstColl.m
+++ b/nstColl.m
@@ -1400,7 +1400,7 @@ classdef nstColl < handle
         function varEst = estimateVarianceAcrossTrials(nstCollObj,numBasis,windowTimes,numIter,fitType)
             %returns a estimate of the variance within each basis
             if(nargin<5 || isempty(fitType))
-               fitType = 'poisson'; 
+               fitType = 'poisson';
             end
             if(nargin<4 || isempty(numIter))
                 numIter=20;
@@ -1420,50 +1420,74 @@ classdef nstColl < handle
             delta = 1/nstCollObj.sampleRate;
             minTime = nstCollObj.minTime;
             maxTime = nstCollObj.maxTime;
-            
 
-            for i=1:min([numIter/2 sumNumber])
-
+            % FIX (nstat-python#249): use an explicit shared column counter
+            % across both forward and backward loops. The prior code used
+            % the realization index `i` as the column index in the
+            % backward loop, silently auto-expanding `coeffs` to
+            % (numBasis, numRealizations) and then trying to recover via a
+            % per-row "remove zero columns" pass. That recovery fails when
+            % any coefficient is exactly zero. The Python port surfaced
+            % the same bug as an IndexError; explicit counter is the
+            % portable fix.
+            halfIters = min([numIter/2 sumNumber]);
+            col = 1;
+            for i=1:halfIters
                 spikeCollTemp=nstColl(nstCollObj.getNST(i:i+sumNumber));
 
-
                 spikeCollTemp.resample(1/delta);
                 spikeCollTemp.setMaxTime(maxTime);
                 spikeCollTemp.setMinTime(minTime);
                 [~, ~, psthResultT] =spikeCollTemp.psthGLM(basisWidth,windowTimes,fitType);
-                coeffs(:,i)=psthResultT.getCoeffs;
+                coeffs(:,col)=psthResultT.getCoeffs;
+                col = col + 1;
             end
-            for i=numRealizations:-1:(numRealizations-min([numIter/2 sumNumber])+1)
+            for i=numRealizations:-1:(numRealizations-halfIters+1)
+                if col > numIter, break; end
                 spikeCollTemp=nstColl(nstCollObj.getNST(i:-1:i-sumNumber));
 
-
                 spikeCollTemp.resample(1/delta);
                 spikeCollTemp.setMaxTime(maxTime);
                 spikeCollTemp.setMinTime(minTime);
                 [~, ~, psthResultT] =spikeCollTemp.psthGLM(basisWidth,windowTimes,fitType);
-                coeffs(:,i)=psthResultT.getCoeffs;
-            end 
-            
-            %Remove zero columns
-            for i=1:size(coeffs,1)
-                CoeffsTemp(i,:) = coeffs(i,coeffs(i,:)~=0);
+                coeffs(:,col)=psthResultT.getCoeffs;
+                col = col + 1;
             end
-            
-            coeffs=CoeffsTemp;
-            NTerms=4;A=1; B=ones(1,NTerms)./NTerms;
-            coeffs(isnan(coeffs))=0;
-%             coeffs(exp(coeffs)/delta>10)=log(10*delta); %dont allow for really large coeffs
-            if(size(coeffs',1)>3*NTerms)
-                fcoeffs = filtfilt(B,A,coeffs')';
-            else
-                fcoeffs = coeffs;
+
+            % FIX (nstat-python#249, "Bug 3"): mask empty-bin sentinel
+            % coefficients before computing across-subset variance. A
+            % unit-impulse basis bin with no spikes in a subset is
+            % unidentified, and the inner GLM floors its coefficient at a
+            % large-negative numerical sentinel (~ -120 for log(0)). The
+            % previous code only filtered zeros, so the sentinels flowed
+            % into nanvar and inflated Q by 100-1000x ("Q median 4539 ->
+            % 4.5" in the Python port), which then blows up the SSGLM EM
+            % even on clean data. Symmetric bound: |log-rate| >= 30 means
+            % rate outside (3e-11/delta, 1e13/delta) Hz -- non-physical.
+            %
+            % Per-row valid-coefficient series (rows may differ in count
+            % after masking) replaces the previous CoeffsTemp reshape
+            % that assumed every row had the same number of nonzeros.
+            SENTINEL = 30;
+            coeffs = coeffs(:, 1:col-1);   % trim to actually-filled columns
+            nBasis = size(coeffs,1);
+            varEst = zeros(nBasis,1);
+            NTerms = 4; A = 1; B = ones(1,NTerms)./NTerms;
+            for r = 1:nBasis
+                rowR = coeffs(r,:);
+                valid = rowR(rowR ~= 0 & abs(rowR) < SENTINEL & ~isnan(rowR));
+                if numel(valid) > 3*NTerms
+                    smoothed = filtfilt(B, A, valid);
+                else
+                    smoothed = valid;
+                end
+                if numel(smoothed) >= 2
+                    varEst(r) = var(diff(smoothed), 'omitnan');
+                else
+                    varEst(r) = 0;
+                end
             end
-            
-            varEst=nanvar(diff(fcoeffs,[],2),[],2);
-
-%             varEst(varEst>.001)=0.0001; %avoid large estimates of the sample variance
-
-            varEst=diag(varEst);
+            varEst = diag(varEst);
             echo on;
         end
         function windowedSpikeTimes=getSpikeTimes(nstCollObj, minTime, maxTime)

--- a/tests/unit/testSSGLMRegularization.m
+++ b/tests/unit/testSSGLMRegularization.m
@@ -1,0 +1,182 @@
+classdef testSSGLMRegularization < matlab.unittest.TestCase
+    %TESTSSGLMREGULARIZATION numerical-health tests for the SSGLM EM
+    % init + posterior-covariance update.
+    %
+    % MATLAB-side regression tests for the two algorithmic bugs fixed in
+    % parallel with cajigaslab/nSTAT-python#249:
+    %
+    %   1. estimateVarianceAcrossTrials propagated -120 empty-bin sentinel
+    %      coefficients into Q, exploding the state-noise variance and
+    %      blowing up the SSGLM EM even on clean data. The MATLAB version
+    %      suffered the same flaw -- the previous "remove zero columns"
+    %      pass only filtered exact-zero entries and the magnitude clamp
+    %      attempt at line 1464 was commented out.
+    %
+    %   2. PPSS_EStep posterior-covariance update used a bare inv + eig
+    %      flow. For high-rate / sparse-bin units, sumValMat reaches
+    %      non-finite magnitudes (lambdaDelta up to e^30 ~ 1e13), making
+    %      the inverse non-finite and the eigendecomposition error with
+    %      "Eigenvalues did not converge". The fix is a robust PSD inverse
+    %      + a physical bound on the log-rate state so a diverged trial
+    %      cannot poison the next trial's prior.
+    %
+    % The SSGLM path was previously only signature-checked in
+    % testNstatDecodingSSGLM (PPSS_MStep parity). The EM init + E-step
+    % were never exercised end-to-end in unit tests, so neither bug
+    % surfaced before they were caught in the Python port.
+
+    methods (Test)
+
+        function testQIsPhysicalOnCleanData(tc)
+            %TESTQISPHYSICALONCLEANDATA Q must be finite and O(1) on clean
+            % synthetic Poisson trials. Pre-fix Q median was ~1e3-1e4 from
+            % the empty-bin sentinel contamination.
+            rng(1, 'twister');
+            coll = makePoissonTrialColl(40, 12.0, 1.5, 1000.0);
+
+            Q = coll.estimateVarianceAcrossTrials(8, [], 4, 'poisson');
+
+            tc.verifySize(Q, [8 8], 'Q must be (numBasis x numBasis)');
+            tc.verifyTrue(all(isfinite(Q(:))), ...
+                'Q must be finite (was Inf/NaN with sentinel coefficients in Q init)');
+            tc.verifyLessThan(median(diag(Q)), 10.0, ...
+                ['Q median must be O(1) on clean stationary data ' ...
+                 '(pre-fix: ~1e3-1e4 from -120 sentinel contamination)']);
+            tc.verifyGreaterThanOrEqual(min(diag(Q)), 0, ...
+                'Q is a variance estimate; entries must be non-negative');
+        end
+
+        function testRobustPsdInverseScrubsNonFiniteEntries(tc)
+            %TESTROBUSTPSDINVERSESCRUBSNONFINITEENTRIES the helper must
+            % return a finite PSD matrix even when the precision input
+            % contains NaN/Inf entries (the path that crashed the EM).
+            dim = 4;
+            invW = eye(dim);
+            invW(2,3) = NaN;
+            invW(3,4) = Inf;
+
+            W = nstat.decoding.SSGLM.robustPsdInverse(invW, dim);
+
+            tc.verifyTrue(all(isfinite(W(:))), ...
+                'robustPsdInverse output must be finite for non-finite input');
+            tc.verifyEqual(W, W.', 'AbsTol', 1e-10, ...
+                'robustPsdInverse output must be symmetric');
+            eigvals = eig(W);
+            tc.verifyGreaterThanOrEqual(min(eigvals), -1e-10, ...
+                'robustPsdInverse output must be PSD');
+        end
+
+        function testRobustPsdInverseMatchesEigFlooredInvOnConditionedInput(tc)
+            %TESTROBUSTPSDINVERSEMATCHESEIGFLOOREDINVONCONDITIONEDINPUT
+            % On a well-conditioned precision matrix the new helper must
+            % be numerically equivalent to the previous flow:
+            %     W = inv(invW); [v,d]=eig(W); d(d<=0)=eps; W = v*d*v';
+            rng(2, 'twister');
+            dim = 5;
+            X = randn(dim, dim);
+            invW = X*X.' + dim*eye(dim);  % well-conditioned SPD
+
+            W_new = nstat.decoding.SSGLM.robustPsdInverse(invW, dim);
+
+            W_old = inv(invW);
+            W_old = 0.5*(W_old + W_old.');
+            [v,d] = eig(W_old);
+            d(d <= 0) = eps;
+            W_old = v*d*v.';
+            W_old = 0.5*(W_old + W_old.');
+
+            tc.verifyEqual(W_new, W_old, 'AbsTol', 1e-9, ...
+                ['On well-conditioned input, robustPsdInverse must match ' ...
+                 'the previous inv+eig-floor flow within round-off']);
+        end
+
+        function testPPSSEMSurvivesHighRateBurstyUnit(tc)
+            %TESTPPSSEMSURVIVESHIGHRATEBURSTYUNIT high firing rate with
+            % silent second-half bins is the pattern that previously made
+            % the E-step error with "Eigenvalues did not converge". After
+            % the fix, EM completes and the returned states are finite
+            % and within the physical bound.
+            rng(3, 'twister');
+            % 30 trials of bursty 120 Hz in first half, silent second half.
+            % The silent bins drive lambdaDelta variance through the roof
+            % in the E-step posterior precision.
+            coll = makeBurstyHighRateTrialColl(30, 120.0, 1.5, 1000.0);
+
+            % Run a single-iteration EM via the same path as nstColl.ssglm
+            % but bypassing the full driver; this isolates the E-step
+            % regularization from the M-step / outer EM loop.
+            dN = coll.dataToMatrix';
+            dN(dN > 1) = 1;
+            numBasis = 6;
+            delta = 1/coll.sampleRate;
+            R = numBasis;
+            % Trivial init -- the test is whether the E-step survives.
+            A = eye(R);
+            Q = 0.01*eye(R);
+            x0 = zeros(R,1);
+            HkAll = cell(size(dN,1),1);
+            for k = 1:size(dN,1)
+                HkAll{k} = 0;
+            end
+            gamma = 0;
+
+            % Pre-fix: this throws "Eigenvalues did not converge" mid-EM.
+            % Post-fix: returns finite states bounded at +/- 50.
+            [x_K, ~, ~, ~, ~, ~] = nstat.decoding.SSGLM.PPSS_EStep( ...
+                A, Q, x0, dN, HkAll, 'poisson', delta, gamma, numBasis);
+
+            tc.verifyTrue(all(isfinite(x_K(:))), ...
+                'E-step output state must be finite on the bursty-high-rate path');
+            tc.verifyLessThanOrEqual(max(abs(x_K(:))), 50 + 1e-6, ...
+                ['log-rate state must respect the physical bound ' ...
+                 '(SSGLM_STATE_BOUND = 50; |x| <= 50 ⟺ rate within ' ...
+                 '(e^-50, e^50)/delta)']);
+        end
+
+    end
+end
+
+
+function coll = makePoissonTrialColl(nTrials, rateHz, durSec, sampleRate)
+    % A clean homogeneous-Poisson trial collection. One nspikeTrain per
+    % trial. All trials share the same neuron name so the collection
+    % represents repeated observations of one neuron (matches
+    % helpfiles/nSTATPaperExamples.m and example03 fixture style;
+    % distinct names would make RunAnalysisForAllNeurons return a cell
+    % instead of a single FitResult, tripping psthGLM:1027).
+    nstCellArr = cell(nTrials, 1);
+    for i = 1:nTrials
+        nSpikes = poissrnd(rateHz * durSec);
+        if nSpikes < 1
+            nSpikes = 1;
+        end
+        spikeTimes = sort(rand(1, nSpikes) * durSec);
+        nstCellArr{i} = nspikeTrain(spikeTimes, 'n1', 1/sampleRate, ...
+            0, durSec);
+    end
+    coll = nstColl(nstCellArr);
+    coll.resample(sampleRate);
+    coll.setMaxTime(durSec);
+end
+
+
+function coll = makeBurstyHighRateTrialColl(nTrials, rateHz, durSec, sampleRate)
+    % High-rate Poisson burst in the first 40% of each trial, silent in
+    % the rest. Silent bins are the pathological pattern that drives the
+    % E-step posterior precision to non-finite values in the unregularized
+    % flow. Single-neuron-across-trials naming convention (see above).
+    nstCellArr = cell(nTrials, 1);
+    burstWindow = 0.4 * durSec;
+    for i = 1:nTrials
+        nSpikes = poissrnd(rateHz * burstWindow);
+        if nSpikes < 1
+            nSpikes = 1;
+        end
+        spikeTimes = sort(rand(1, nSpikes) * burstWindow);
+        nstCellArr{i} = nspikeTrain(spikeTimes, 'n1', 1/sampleRate, ...
+            0, durSec);
+    end
+    coll = nstColl(nstCellArr);
+    coll.resample(sampleRate);
+    coll.setMaxTime(durSec);
+end


### PR DESCRIPTION
Two algorithmic bugs surfaced by [cajigaslab/nSTAT-python#249](https://github.com/cajigaslab/nSTAT-python/issues/248)'s port-audit work also exist in this repo's MATLAB code. Both blow up the SSGLM EM but in ways the existing tests do not exercise (current SSGLM tests only signature-check `PPSS_MStep`; end-to-end SSGLM runs in the helpfiles use precomputed fixtures so they do not trigger the divergence path).

## Bug A — `estimateVarianceAcrossTrials` propagates empty-bin sentinels

**Site**: `nstColl.m:estimateVarianceAcrossTrials`.

When the inner per-subset `psthGLM` hits a unit-impulse basis bin with no spikes, the GLM coefficient for that bin is unidentified and the fitter floors it to a large-negative numerical sentinel (~ -120 for log(0)). The previous "remove zero columns" pass only filtered exact zeros; the magnitude clamp attempt at line 1464 was commented out ("dont allow for really large coeffs"). The sentinels therefore flowed straight into

```matlab
varEst = nanvar(diff(fcoeffs,[],2),[],2);
```

which inflated `Q` by 100-1000×. That `Q` is then handed to `PPSS_EM` as `Q0`, and the EM blows up on inputs the algorithm is supposed to handle. nstat-python observed *"Q median 4539 → 4.5"* with the sentinel mask applied; same dynamics here.

**Fix**: symmetric magnitude mask `|coeff| >= 30` (so log-rate is bounded to physical range) PLUS an explicit shared column counter across the forward and backward loops so the data layout is correct under the mask. The old per-row "nonzero filter then reshape" block is replaced with a per-row valid-coefficient series.

## Bug B — `PPSS_EStep` posterior precision can be non-finite

**Site**: `+nstat/+decoding/SSGLM.m:PPSS_EStep` (shared by `PPSS_EM` and `PPSS_EMFB`).

The Kalman update inverts `invW_u = inv(W_p) + sumValMat`, then `W_u = inv(invW_u)`, then floors the eigenvalues. For high-rate or sparse-bin units, `lambdaDelta = exp(stimK).*histEffect` can reach `e^30 ~ 1e13`, making `sumValMat` (and hence `W_u`) non-finite. The bare `inv + eig` flow then errors with "Eigenvalues did not converge" or returns garbage. `x_u` diverges and poisons the next iteration via `x_p = A*x_u`.

**Fix** (mirrors nstat-python#249's `PPSS_EStep` regularization):

1. New static helper `nstat.decoding.SSGLM.robustPsdInverse` — scrub non-finite entries, symmetrize, add tiny ridge, invert; if non-finite, fall back to `pinv`; if `eig` fails, return `identity * eps`. On well-conditioned input, returns the same PSD matrix the previous code did.
2. Clip the log-rate state to `|x_u| <= SSGLM_STATE_BOUND = 50`. Real states sit near `log(rate * delta) ~ [-12, 5]`; bound at ±50 corresponds to rate in `(e^-50, e^50)/delta` — far outside any physical neural firing rate.

## Tests (`tests/unit/testSSGLMRegularization.m`)

| Test | Asserts |
|---|---|
| `testQIsPhysicalOnCleanData` | 40 Poisson trials @ 12 Hz; `median(diag(Q)) < 10` (was ~1e3-1e4 pre-fix) |
| `testRobustPsdInverseScrubsNonFiniteEntries` | Inject NaN/Inf into precision; output finite + symmetric + PSD |
| `testRobustPsdInverseMatchesEigFlooredInvOnConditionedInput` | Well-conditioned SPD precision → helper matches previous `inv + eig-floor` flow at AbsTol 1e-9. **"No behavioural change on well-conditioned input" guarantee.** |
| `testPPSSEMSurvivesHighRateBurstyUnit` | 30 trials of 120 Hz burst + silent rest; previously crashed mid-EM with "Eigenvalues did not converge". Post-fix: EM runs, states finite, `|x_K| <= SSGLM_STATE_BOUND + eps` |

## Test gate

`tools/run_unit_tests.sh` → **83 / 83 pass** (was 79; +4 new). No regression in existing tests.

## Out of scope

The 1-based vs 0-based indexing artifacts noted in nstat-python#249 ("Bug 1" / "Bug 2" framings) are port-translation issues, not bugs in MATLAB. The column-counter restructure here is for clarity under the new mask, not because the realization-as-column scheme is incorrect — MATLAB's auto-expansion + zero-strip pattern previously recovered the right answer for typical inputs, just opaquely and fragilely.