### PR TITLE
chore(serena): adopt Serena MCP + onboard (versioned config + memories)

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/memories/conventions.md
+++ b/.serena/memories/conventions.md
@@ -1,0 +1,18 @@
+# nSTAT — Conventions & Policies
+
+Canonical policy text = tracked `CONTRIBUTING.md`; agent usage guide = `AGENT_GUIDE.md`; historical bug catalog = `AUDIT_REPORT.md`.
+
+## Source-of-truth rules
+- **`.m` is canonical, not `.mlx`.** `.mlx` Live Scripts are binary/drift-prone. Edit the `.m`; if an `.mlx` drifts, delete it rather than hand-patch. Sole exception: `helpfiles/nSTATPaperExamples.mlx` (2012-paper artifact, preserved deliberately).
+- When smoke-testing an edited helpfile `.m`, watch the `.mlx`-shadows-`.m` trap (an `.mlx` of the same name shadows the `.m` on the MATLAB path) — see CONTRIBUTING.md "Smoke-testing an edited helpfile `.m`".
+- **Never hand-edit generated artifacts:** `helpfiles/*.html`, `helpfiles/helpsearch-v4_0/`, `docs/figures/exampleNN/*.png`, `docs/figures/manifest.json`. They regenerate via `tools/predeploy.sh` / `build_paper_examples` / `publish_all_helpfiles`.
+
+## Parity & figures (invariants)
+- **Numeric baseline** `fixtures/baseline_numeric/` + `tests/TestParityAgainstBaseline.m` = ground truth. A change breaking the baseline is WRONG unless the baseline is deliberately regenerated (`tools/generate_baseline_fixtures.m`).
+- **README figure parity:** committed PNGs under `docs/figures/exampleNN/` ARE the GitHub-rendered docs. Any change to `examples/paper/exampleNN_*.m`, a core class, `+nstat/+decoding/*`, or `tools/+nstat/applyPlotStyle.m` must run `tools/check_readme_figures.sh`. `IDENTICAL`/`TINY`/`NONDETERMINISTIC` → proceed; `SUBSTANTIVE` → regenerate `docs/figures/` and commit PNGs+manifest, or fix the regression.
+
+## Code style
+- MATLAB class/method names are the public API — do not rename.
+- Audit comments use `% FIX:` convention; deprecations use the shim pattern (see `docs/superpowers/plans/2026-05-19-nstat-review-action-plan.md`).
+- Branches `fix/<area>` or `feat/<area>`; short imperative commit subjects.
+- No checked-in git hooks (deliberate maintainer decision; CONTRIBUTING.md pre-push hook is opt-in per developer).

--- a/.serena/memories/core.md
+++ b/.serena/memories/core.md
@@ -1,0 +1,24 @@
+# nSTAT — Core
+
+MATLAB neural Spike Train Analysis Toolbox (Cajigas, Malik & Brown, *J Neurosci Methods* 211:245–264, 2012; PMID 22981419). Repo `cajigaslab/nstat` (public), default branch `master`. Independent Python port lives in the separate repo `cajigaslab/nstat-python` — **keep the two uncoupled**; do not cross-import or sync code between them.
+
+## Source map
+- Root `*.m` (26 files) = public toolbox API classes. Core classes: `Analysis`, `CIF`, `LinearCIF`, `SignalObj`, `FitResult`, `FitResSummary`, `nspikeTrain`, `nstColl`, `CovColl`, `Covariate`, `ConfidenceInterval`, `ConfigColl`, `DecodingAlgorithms`, `Trial`, `TrialConfig`, `History`, `Events`.
+- `+nstat/+decoding/` = modern decoding namespace package: `PPAF`, `PPHF`, `KalmanFilter`, `KF_EM`, `UKF`, `SSGLM`, `PointProcessEM`, `PPLFP`. Private helpers in `+nstat/+decoding/+internal/` (e.g. `computeGainMatrix`).
+- `examples/paper/exampleNN_*.m` = the 5 paper worked examples (regenerate via `regenerate_all_figures.m`).
+- `helpfiles/*.m` = **canonical** help source (`.html` under helpfiles are generated — never hand-edit).
+- `tools/` = local-CI orchestration, figure-parity, release. Plot styling package: `tools/+nstat/` (`applyPlotStyle`, `getPlotStyle`, `setPlotStyle`) — there is no `+plotting` package.
+- `tests/` = `unit/`, `integration/`, `python_port_fidelity/` (discovered by `run_tests.m`).
+- `fixtures/baseline_numeric/` = ground-truth numeric parity baseline.
+- `data/`, `docs/`, `libraries/`, `porting/`, `release/`, `slprj/` (Simulink build).
+
+## Project-wide invariants
+- MATLAB-style class/method names ARE the public API — never rename.
+- `.m` is canonical, never `.mlx` (see `mem:conventions`).
+- No MATLAB CI exists (license doesn't cover GitHub runners) — the local gate is the only gate. Do NOT add a MATLAB CI workflow.
+
+## Focused memories
+- Stack/versions/build: `mem:tech_stack`
+- Commands to run (test/parity/release): `mem:suggested_commands`
+- Code/style/policy invariants (.m-canonical, figure parity, baseline): `mem:conventions`
+- Definition-of-done gate before commit/push: `mem:task_completion`

--- a/.serena/memories/memory_maintenance.md
+++ b/.serena/memories/memory_maintenance.md
@@ -1,0 +1,33 @@
+# Memory Maintenance
+
+## Discovery Model
+
+- Core principle: progressive discovery through references, building a graph of memories.
+- Initially, agents are provided with the list of all memories (names only).
+- Agents should read `mem:core` as the top-level entry point (graph root).
+  This memory should contain references to other memories covering major project domains.
+  The referenced memories shall, in turn, shall contain references to even more specific memories, and so on.
+  The depth of the graph shall depend on the project complexity.
+- Use topics/folders to group related memories in order to make the content structure explicit.
+  Folders can mirror project structure (e.g. modules like frontend/backend) or topics like debugging, architecture, etc.
+- Memory references must use a mem: prefix inside backticks, e.g. `mem:frontend/core`.
+  The surrounding text should clearly indicate when to read the memory/which content to expect.
+  The text should provide more precise guidance than the memory name alone, 
+  i.e. avoid a reference like "frontend debugging: `mem:frontend/debugging` and instead make clear which aspects of frontend debugging are covered.
+- Memories themselves should not contain information about when to read them; this is the responsibility of the referring memory.
+
+## Style
+
+Dense agent notes, not prose docs. Prefer invariants, terse bullets. 
+Avoid obvious context, rationale, and examples unless they prevent likely mistakes. 
+Keep guidance durable and generalizable, not task-local.
+
+## Add/update threshold
+
+Add or update memories only with stable, non-obvious project conventions that avoid complex rediscovery in the future.
+Do not add: quick-read facts; generic language/framework knowledge; one-off task notes; volatile line-level details; behavior likely to change soon.
+
+## Maintenance Actions
+
+- Renaming memories: References are updated automatically if handled via Serena's memory rename tool.
+- Checking for stale memories (e.g. after deletion): Call `serena memories check` for a report.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,20 @@
+# nSTAT — Suggested Commands
+
+Run from repo root. Shell gates (macOS/Darwin, zsh):
+
+- `tools/run_unit_tests.sh` — local test gate, ~20 unit tests. Run before every push.
+- `tools/run_unit_tests.sh --integration` — adds slower KS-oracle integration tests (~2–4 min).
+- `tools/check_readme_figures.sh` — README/paper-example figure-parity drift detector (~4–5 min).
+- `tools/check_bug_patterns.sh` — bug-pattern lint.
+- `tools/predeploy.sh` — full pre-release gate, ~30–45 min (6 chained steps).
+
+Inside MATLAB:
+- `run_tests` — `matlab.unittest` suite over `tests/` (recursive).
+- `addpath(fullfile(pwd,'tools')); run_all_checks(...)` — full local-CI orchestrator.
+- `addpath(fullfile(pwd,'tools')); tools.stamp_release('vX.Y.Z')` — stamp version AFTER predeploy passes.
+- `build_paper_examples` / `publish_all_helpfiles` — regenerate example figures / helpfiles.
+- `tools/generate_baseline_fixtures.m` — regenerate numeric parity baseline (only when deliberately changing ground truth).
+
+MATLAB override: `MATLAB_BIN=<path>/bin/matlab tools/run_unit_tests.sh` or `--matlab-path <...>`.
+
+Darwin note: BSD userland (`ls`, `grep`, `sed` differ from GNU); `mdfind` for spotlight search. Git over `https://github.com/cajigaslab/nstat`, branch `master`.

--- a/.serena/memories/task_completion.md
+++ b/.serena/memories/task_completion.md
@@ -1,0 +1,11 @@
+# nSTAT — Definition of Done
+
+No MATLAB CI exists — the local gate is the ONLY gate. Before declaring a coding task done / before pushing:
+
+1. `tools/run_unit_tests.sh` must pass (add `--integration` when touching decoding/KS-oracle paths).
+2. If the change touches `examples/paper/exampleNN_*.m`, any core class, `+nstat/+decoding/*`, or `tools/+nstat/applyPlotStyle.m` → run `tools/check_readme_figures.sh`. `SUBSTANTIVE` diff means regenerate `docs/figures/` (commit PNGs + `manifest.json`) or fix the regression before done.
+3. If numeric behavior changed, confirm `tests/TestParityAgainstBaseline.m` still passes (baseline in `fixtures/baseline_numeric/`). Do not regenerate the baseline to make a test pass unless the change to ground truth is intended.
+
+Release path (only when cutting a version): `tools/predeploy.sh` (full ~30–45 min gate) → in MATLAB `tools.stamp_release('vX.Y.Z')` → commit + tag → `git push origin master --tags`.
+
+If MATLAB is unavailable in the current shell, report that and route the actual test run to the user — do not claim the gate passed without running it.

--- a/.serena/memories/tech_stack.md
+++ b/.serena/memories/tech_stack.md
@@ -1,0 +1,10 @@
+# nSTAT — Tech Stack
+
+- Language: **MATLAB**. Default toolchain **R2025b** at `/Applications/MATLAB_R2025b.app`. R2026a also installed (`/Applications/MATLAB_R2026a.app`); `matlab` on PATH is `/opt/homebrew/bin/matlab` (shell shim).
+- Override MATLAB used by test scripts via `MATLAB_BIN=/Applications/MATLAB_R2024b.app/bin/matlab` or `--matlab-path`. `run_unit_tests.sh` exits 2 if MATLAB not found.
+- Build/packaging: MATLAB toolbox project — `buildfile.m`, `toolboxOptions.m`, `packageToolbox.m`, `nSTAT_Install.m`.
+- Simulink present (`slprj/`, `*.slxc`).
+- Auxiliary tooling in Python + bash under `tools/` (help-system audit, lint, drift checks) and shell gate scripts.
+- Version: v1.4.0. `CITATION.cff` (cff-version 1.2.0) + `RELEASE_NOTES.md` track releases.
+- Git-LFS tracks `*.mat` and `*.slxc` (see `.gitattributes`).
+- Serena languages configured: matlab (default), cpp, python, bash.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,136 @@
+# the name by which the project can be referenced within Serena
+project_name: "nstat"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- matlab
+- cpp
+- python
+- bash
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []


### PR DESCRIPTION
Versions the Serena MCP project config (`.serena/project.yml`) and onboarding memories (`core`, `tech_stack`, `suggested_commands`, `conventions`, `task_completion`, `memory_maintenance`) so any clone or future agent session on this repo inherits the semantic-tool setup and repo conventions.

Machine-local files (`/cache`, `project.local.yml`) are excluded via the nested `.serena/.gitignore`.

Mirrors the same adoption in the Python port (cajigaslab/nSTAT-python#251).

Generated with [Claude Code](https://claude.com/claude-code)